### PR TITLE
CTCP-flaky-test: Fixing flaky test on LocationOfGoodsIdentificationSpec

### DIFF
--- a/test/controllers/locationOfGoods/IdentificationControllerSpec.scala
+++ b/test/controllers/locationOfGoods/IdentificationControllerSpec.scala
@@ -39,7 +39,9 @@ import scala.concurrent.Future
 
 class IdentificationControllerSpec extends SpecBase with AppWithDefaultMockFixtures with ScalaCheckPropertyChecks with Generators {
 
-  private val ids = arbitrary[Seq[LocationOfGoodsIdentification]].sample.value
+  val ids: Seq[LocationOfGoodsIdentification] =
+    Gen.containerOfN[Seq, LocationOfGoodsIdentification](2, arbitrary[LocationOfGoodsIdentification]).sample.value
+
   private val id1 = ids.head
 
   private val formProvider                                                            = new EnumerableFormProvider()

--- a/test/controllers/locationOfGoods/LocationTypeControllerSpec.scala
+++ b/test/controllers/locationOfGoods/LocationTypeControllerSpec.scala
@@ -38,8 +38,9 @@ import scala.concurrent.Future
 
 class LocationTypeControllerSpec extends SpecBase with AppWithDefaultMockFixtures with Generators {
 
-  private val lts = Gen.nonEmptyListOf(arbitrary[LocationType]).sample.value
-  private val lt  = lts.head
+  private val lts: Seq[LocationType] =
+    Gen.containerOfN[Seq, LocationType](2, arbitrary[LocationType]).sample.value
+  private val lt = lts.head
 
   private val formProvider                                 = new EnumerableFormProvider()
   private val form                                         = formProvider("locationOfGoods.locationType", lts)


### PR DESCRIPTION
if the generated sequence of LocationOfGoodsIdentification is of length 1 then it redirects. This already has a test case so bumped the generator to ensure a list > 2 is made.