### PR TITLE
CTCP-4669 Allow system to display, change and remove border means of transport that come from IE015

### DIFF
--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -18,8 +18,9 @@ package controllers
 
 import cats.data.OptionT
 import controllers.actions._
+import models.messages.{Data, MessageData}
+import models.requests.OptionalDataRequest
 import models.{LocalReferenceNumber, UserAnswers}
-import models.messages.MessageData
 import play.api.i18n.I18nSupport
 import play.api.libs.json.JsObject
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -28,6 +29,7 @@ import services.DepartureMessageService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.TimeMachine
+import utils.transformer.{IdentificationNumberTransformer, IdentificationTransformer}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -38,6 +40,7 @@ class IndexController @Inject() (
   sessionRepository: SessionRepository,
   val controllerComponents: MessagesControllerComponents,
   service: DepartureMessageService,
+  identificationTransformer: IdentificationTransformer,
   timeMachine: TimeMachine
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
@@ -49,17 +52,26 @@ class IndexController @Inject() (
         departureData <- OptionT(service.getDepartureData(departureId))
         lrn           <- OptionT.liftF(retrieveLRN(departureData.data, departureId))
         _ <- OptionT.liftF(
-          sessionRepository
-            .set(
-              request.userAnswers.getOrElse(
-                UserAnswers(departureId, request.eoriNumber, lrn.value, JsObject.empty, timeMachine.now(), departureData.data)
-              )
-            )
+          request.userAnswers match {
+            case Some(userAnswers) => sessionRepository.set(userAnswers)
+            case None              => generateFromDepartureData(departureId, request, departureData, lrn)
+          }
         )
       } yield departureData.data.isDataComplete match {
         case true  => Redirect(controllers.routes.CheckInformationController.onPageLoad(departureId))
         case false => Redirect(controllers.routes.MoreInformationController.onPageLoad(departureId))
       }).getOrElse(Redirect(controllers.routes.ErrorController.technicalDifficulties()))
+  }
+
+  private def generateFromDepartureData(departureId: String, request: OptionalDataRequest[AnyContent], departureData: Data, lrn: LocalReferenceNumber)(implicit
+    hc: HeaderCarrier
+  ): Future[Boolean] = {
+    val userAnswers = UserAnswers(departureId, request.eoriNumber, lrn.value, JsObject.empty, timeMachine.now(), departureData.data)
+    for {
+      withIdentification       <- identificationTransformer.fromDepartureDataToUserAnswers(userAnswers)
+      withIdentificationNumber <- Future.fromTry(IdentificationNumberTransformer.fromDepartureDataToUserAnswers(withIdentification))
+      result                   <- sessionRepository.set(withIdentificationNumber)
+    } yield result
   }
 
   private def retrieveLRN(messageData: MessageData, departureId: String)(implicit hc: HeaderCarrier): Future[LocalReferenceNumber] =

--- a/app/controllers/transport/border/active/IdentificationController.scala
+++ b/app/controllers/transport/border/active/IdentificationController.scala
@@ -58,16 +58,7 @@ class IdentificationController @Inject() (
       implicit request =>
         service.getMeansOfTransportIdentificationTypesActive(index, request.userAnswers.get(BorderModeOfTransportPage)).flatMap {
           identifiers =>
-            def identificationFromDepartureData = {
-              val identificationCode = request.userAnswers.departureData.Consignment.ActiveBorderTransportMeans.flatMap(
-                list => list.lift(index.position).flatMap(_.typeOfIdentification)
-              )
-              identificationCode.flatMap(
-                code => identifiers.find(_.code == code)
-              )
-            }
-
-            val preparedForm = request.userAnswers.get(IdentificationPage(index)).orElse(identificationFromDepartureData) match {
+            val preparedForm = request.userAnswers.get(IdentificationPage(index)) match {
               case None        => form(identifiers)
               case Some(value) => form(identifiers).fill(value)
             }

--- a/app/controllers/transport/border/active/IdentificationNumberController.scala
+++ b/app/controllers/transport/border/active/IdentificationNumberController.scala
@@ -57,12 +57,6 @@ class IdentificationNumberController @Inject() (
 
           val fillForm = request.userAnswers
             .get(IdentificationNumberPage(activeIndex))
-            .orElse(
-              request.userAnswers.departureData.Consignment.ActiveBorderTransportMeans
-                .flatMap(
-                  seq => seq.lift(activeIndex.position).flatMap(_.identificationNumber)
-                )
-            )
 
           val preparedForm = fillForm match {
             case None        => form

--- a/app/navigation/BorderNavigator.scala
+++ b/app/navigation/BorderNavigator.scala
@@ -90,14 +90,11 @@ class BorderNavigator @Inject() () extends Navigator {
       case _          => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
     }
 
-  private def identificationCheckRoute(ua: UserAnswers, departureId: String, activeIndex: Index): Option[Call] = {
-    val ie015IdentificationNumber =
-      ua.departureData.Consignment.ActiveBorderTransportMeans.flatMap(_.lift(activeIndex.position).flatMap(_.identificationNumber))
-    (ua.get(IdentificationNumberPage(activeIndex)), ie015IdentificationNumber) match {
-      case (None, None) => IdentificationNumberPage(activeIndex).route(ua, departureId, CheckMode)
-      case _            => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+  private def identificationCheckRoute(ua: UserAnswers, departureId: String, activeIndex: Index): Option[Call] =
+    ua.get(IdentificationNumberPage(activeIndex)) match {
+      case None => IdentificationNumberPage(activeIndex).route(ua, departureId, CheckMode)
+      case _    => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
     }
-  }
 
   private def identificationNumberCheckRoute(ua: UserAnswers, departureId: String, activeIndex: Index): Option[Call] = {
     val ie015Nationality = ua.departureData.Consignment.ActiveBorderTransportMeans.flatMap(_.lift(activeIndex.position).flatMap(_.nationality))

--- a/app/services/MeansOfTransportIdentificationTypesActiveService.scala
+++ b/app/services/MeansOfTransportIdentificationTypesActiveService.scala
@@ -34,6 +34,13 @@ class MeansOfTransportIdentificationTypesActiveService @Inject() (referenceDataC
   ): Future[Seq[Identification]] =
     referenceDataConnector.getMeansOfTransportIdentificationTypesActive().map(filter(_, index, borderModeOfTransport)).map(sort)
 
+  def getMeansOfTransportIdentificationTypesActive()(implicit
+    hc: HeaderCarrier
+  ): Future[Seq[Identification]] =
+    referenceDataConnector
+      .getMeansOfTransportIdentificationTypesActive()
+      .map(_.toList)
+
   def getBorderMeansIdentification(code: String)(implicit hc: HeaderCarrier): Future[Identification] =
     referenceDataConnector.getMeansOfTransportIdentificationTypeActive(code).map(_.head)
 

--- a/app/utils/ActiveBorderTransportMeansAnswersHelper.scala
+++ b/app/utils/ActiveBorderTransportMeansAnswersHelper.scala
@@ -58,32 +58,20 @@ class ActiveBorderTransportMeansAnswersHelper(
     id = Some("change-add-identification-for-the-border-means-of-transport")
   )
 
-  def identificationType: Future[Option[SummaryListRow]] =
-    fetchValue[Identification](
+  def identificationType: Option[SummaryListRow] =
+    buildRowWithAnswer[Identification](
       page = IdentificationPage(activeIndex),
-      valueFromDepartureData = userAnswers.departureData.Consignment.ActiveBorderTransportMeans.flatMap(
-        seq => seq.lift(activeIndex.position).flatMap(_.typeOfIdentification)
-      ),
-      refDataLookup = cyaRefDataService.getBorderMeansIdentification
-    ).map {
-      identification =>
-        buildRowWithAnswer[Identification](
-          page = IdentificationPage(activeIndex),
-          optionalAnswer = identification,
-          formatAnswer = formatDynamicEnumAsText(_),
-          prefix = "transport.border.active.identification",
-          id = Some("change-identification")
-        )
-    }
+      optionalAnswer = userAnswers.get(IdentificationPage(activeIndex)),
+      formatAnswer = formatDynamicEnumAsText(_),
+      prefix = "transport.border.active.identification",
+      id = Some("change-identification")
+    )
 
-  def identificationNumber: Option[SummaryListRow] = getAnswerAndBuildRow[String](
+  def identificationNumber: Option[SummaryListRow] = buildRowWithAnswer[String](
     page = IdentificationNumberPage(activeIndex),
+    optionalAnswer = userAnswers.get(IdentificationNumberPage(activeIndex)),
     formatAnswer = formatAsText,
     prefix = "transport.border.active.identificationNumber",
-    findValueInDepartureData = _.Consignment.ActiveBorderTransportMeans
-      .flatMap(
-        seq => seq.lift(activeIndex.position).flatMap(_.identificationNumber)
-      ),
     id = Some("change-identification-number")
   )
 
@@ -161,13 +149,12 @@ class ActiveBorderTransportMeansAnswersHelper(
     }
 
   def getSection(): Future[Section] = {
-    val identificationTypeFuture = identificationType
-    val nationalityFuture        = nationality
-    val customsOfficeFuture      = customsOffice
+    val nationalityFuture   = nationality
+    val customsOfficeFuture = customsOffice
     for {
       addBorderMeansOfTransportYesNoRow <-
         if (userAnswers.departureData.Consignment.ActiveBorderTransportMeans.isDefined) successful(addBorderMeansOfTransportYesNo) else successful(None)
-      identificationTypeRow             <- identificationTypeFuture
+      identificationTypeRow             <- successful(identificationType)
       identificationNumberRow           <- successful(identificationNumber)
       nationalityRow                    <- nationalityFuture
       customsOfficeRow                  <- customsOfficeFuture

--- a/app/utils/transformer/IdentificationNumberTransformer.scala
+++ b/app/utils/transformer/IdentificationNumberTransformer.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.transformer
+
+import models.{Index, UserAnswers}
+import pages.transport.border.active.IdentificationNumberPage
+
+import scala.util.Try
+
+object IdentificationNumberTransformer {
+
+  def fromDepartureDataToUserAnswers(userAnswers: UserAnswers): Try[UserAnswers] = {
+    val identificationNumbers = userAnswers.departureData.Consignment.ActiveBorderTransportMeans.toList.flatten.flatMap(_.identificationNumber)
+    val pageAndValueList = identificationNumbers.zipWithIndex.map {
+      case (identificationNumber, i) =>
+        val index = Index(i)
+        (IdentificationNumberPage(index), identificationNumber)
+    }
+    pageAndValueList.foldLeft(Try(userAnswers)) {
+      (accTry, pageAndValue) =>
+        accTry.flatMap(_.set(pageAndValue._1, pageAndValue._2))
+    }
+  }
+}

--- a/app/utils/transformer/IdentificationTransformer.scala
+++ b/app/utils/transformer/IdentificationTransformer.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.transformer
+
+import models.messages.Data
+import models.reference.transport.border.active.Identification
+import models.{Index, UserAnswers}
+import pages.transport.border.active.IdentificationPage
+import services.MeansOfTransportIdentificationTypesActiveService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class IdentificationTransformer @Inject() (identificationService: MeansOfTransportIdentificationTypesActiveService)(implicit
+  ec: ExecutionContext
+) {
+
+  private def generatePageAndValues(departureDataIdentificationCodes: Seq[String],
+                                    identificationList: Seq[Identification]
+  ): Seq[(IdentificationPage, Identification)] =
+    departureDataIdentificationCodes.zipWithIndex.flatMap {
+      case (code, i) =>
+        val index = Index(i)
+        identificationList
+          .find(_.code == code)
+          .map(
+            identification => (IdentificationPage(index), identification)
+          )
+    }
+
+  def fromDepartureDataToUserAnswers(userAnswers: UserAnswers)(implicit
+    hc: HeaderCarrier
+  ): Future[UserAnswers] =
+    identificationService.getMeansOfTransportIdentificationTypesActive().flatMap {
+      identifications =>
+        val departureDataIdentificationCodes = userAnswers.departureData.Consignment.ActiveBorderTransportMeans.toList.flatten.flatMap(_.typeOfIdentification)
+        val pageAndValueList                 = generatePageAndValues(departureDataIdentificationCodes, identifications)
+        val updatedUserAnswersTry = pageAndValueList.foldLeft(Try(userAnswers)) {
+          (accTry, pageAndValue) =>
+            accTry.flatMap(_.set(pageAndValue._1, pageAndValue._2))
+        }
+        Future.fromTry(updatedUserAnswersTry)
+    }
+
+}

--- a/test/base/TestMessageData.scala
+++ b/test/base/TestMessageData.scala
@@ -61,12 +61,15 @@ object TestMessageData {
     Some(contactPerson)
   )
 
+  val activeBorderTransportMeansIdentification       = "10"
+  val activeBorderTransportMeansIdentificationNumber = "BX857GGE"
+
   val activeBorderTransportMeans: List[ActiveBorderTransportMeans] = List(
     ActiveBorderTransportMeans(
       "11",
       Some("GB000028"),
-      Some("10"),
-      Some("BX857GGE"),
+      Some(activeBorderTransportMeansIdentification),
+      Some(activeBorderTransportMeansIdentificationNumber),
       Some("FR"),
       Some("REF2")
     )

--- a/test/controllers/transport/border/active/IdentificationControllerSpec.scala
+++ b/test/controllers/transport/border/active/IdentificationControllerSpec.scala
@@ -16,12 +16,11 @@
 
 package controllers.transport.border.active
 
-import base.TestMessageData.activeBorderTransportMeans
 import base.{AppWithDefaultMockFixtures, SpecBase}
 import controllers.routes
 import forms.EnumerableFormProvider
 import generators.Generators
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import models.reference.TransportMode.BorderMode
 import models.reference.transport.border.active.Identification
 import org.mockito.ArgumentMatchers.any
@@ -91,29 +90,6 @@ class IdentificationControllerSpec extends SpecBase with AppWithDefaultMockFixtu
       val userAnswers = emptyUserAnswers
         .setValue(BorderModeOfTransportPage, BorderMode("4", "Air"))
         .setValue(IdentificationPage(index), identificationType1)
-      setExistingUserAnswers(userAnswers)
-
-      val request = FakeRequest(GET, identificationRoute)
-
-      val result = route(app, request).value
-
-      val filledForm = form.bind(Map("value" -> identificationType1.code))
-
-      val view = injector.instanceOf[IdentificationView]
-
-      status(result) mustEqual OK
-
-      contentAsString(result) mustEqual
-        view(filledForm, departureId, identificationTypes, mode, index)(request, messages).toString
-    }
-
-    "must populate the view correctly on a GET when the question has previously been answered in the IE015" in {
-      when(mockMeansOfTransportIdentificationTypesActiveService.getMeansOfTransportIdentificationTypesActive(any(), any())(any()))
-        .thenReturn(Future.successful(identificationTypes))
-
-      val userAnswers = UserAnswers.setBorderMeansAnswersLens.set(
-        Option(Seq(activeBorderTransportMeans.head.copy(typeOfIdentification = Some(identificationType1.code))))
-      )(emptyUserAnswers)
       setExistingUserAnswers(userAnswers)
 
       val request = FakeRequest(GET, identificationRoute)

--- a/test/controllers/transport/border/active/IdentificationNumberControllerSpec.scala
+++ b/test/controllers/transport/border/active/IdentificationNumberControllerSpec.scala
@@ -20,7 +20,6 @@ import base.{AppWithDefaultMockFixtures, SpecBase}
 import controllers.routes
 import forms.border.IdentificationNumberFormProvider
 import generators.Generators
-import models.messages.ActiveBorderTransportMeans
 import models.reference.transport.border.active.Identification
 import models.{NormalMode, UserAnswers}
 import org.mockito.ArgumentMatchers.any
@@ -84,42 +83,6 @@ class IdentificationNumberControllerSpec extends SpecBase with AppWithDefaultMoc
           contentAsString(result) mustEqual
             view(form, departureId, mode, index, identifier.asString)(request, messages).toString
       }
-    }
-
-    "must populate the view correctly on a GET when the question has previously been answered in the 15" in {
-
-      when(mockMeansOfTransportIdentificationTypesActiveService.getBorderMeansIdentification(any())(any()))
-        .thenReturn(Future.successful(identificationType1))
-
-      val userAnswers = UserAnswers.setBorderMeansAnswersLens.set(
-        Some(
-          Seq(
-            ActiveBorderTransportMeans(
-              sequenceNumber = "99",
-              customsOfficeAtBorderReferenceNumber = None,
-              typeOfIdentification = Some(identificationType1.code),
-              identificationNumber = Some(identificationType1.code),
-              nationality = None,
-              conveyanceReferenceNumber = None
-            )
-          )
-        )
-      )(emptyUserAnswers)
-
-      setExistingUserAnswers(userAnswers)
-
-      val request    = FakeRequest(GET, identificationNumberRoute)
-      val filledForm = form.bind(Map("value" -> "40"))
-
-      val result = route(app, request).value
-
-      val view = injector.instanceOf[IdentificationNumberView]
-
-      status(result) mustEqual OK
-
-      contentAsString(result) mustEqual
-        view(filledForm, departureId, mode, index, identificationType1.asString)(request, messages).toString
-
     }
 
     "must populate the view correctly on a GET when the question has previously been answered" in {

--- a/test/navigator/BorderNavigatorSpec.scala
+++ b/test/navigator/BorderNavigatorSpec.scala
@@ -575,21 +575,13 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
 
         }
 
-        "to CYA page when identification does exist in the 170" in {
-
+        "to CYA page when identification number exist in the 170" in {
           val userAnswers = emptyUserAnswers
             .setValue(AddBorderMeansOfTransportYesNoPage, true)
             .setValue(IdentificationPage(activeIndex), Identification("Air", "desc"))
+            .setValue(IdentificationNumberPage(activeIndex), "identificationNumber")
           navigator
             .nextPage(IdentificationPage(activeIndex), userAnswers, departureId, CheckMode)
-            .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-
-        }
-
-        "to CYA page when identification does exist in the 15/13" in {
-
-          navigator
-            .nextPage(IdentificationPage(activeIndex), emptyUserAnswers, departureId, CheckMode)
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
 
         }

--- a/test/services/MeansOfTransportIdentificationTypesActiveServiceSpec.scala
+++ b/test/services/MeansOfTransportIdentificationTypesActiveServiceSpec.scala
@@ -135,6 +135,21 @@ class MeansOfTransportIdentificationTypesActiveServiceSpec extends SpecBase with
           verify(mockRefDataConnector).getMeansOfTransportIdentificationTypesActive()(any(), any())
         }
       }
+
+      "must return all identification types when not filtered" in {
+
+        when(mockRefDataConnector.getMeansOfTransportIdentificationTypesActive()(any(), any()))
+          .thenReturn(
+            Future.successful(
+              NonEmptyList(identification1, List(identification2, identification3, identification4, identification5, identification6, identification7))
+            )
+          )
+
+        service.getMeansOfTransportIdentificationTypesActive().futureValue mustBe
+          Seq(identification1, identification2, identification3, identification4, identification5, identification6, identification7)
+
+        verify(mockRefDataConnector).getMeansOfTransportIdentificationTypesActive()(any(), any())
+      }
     }
 
     "getBorderMeansIdentification" in {

--- a/test/utils/ActiveBorderTransportMeansAnswersHelperSpec.scala
+++ b/test/utils/ActiveBorderTransportMeansAnswersHelperSpec.scala
@@ -20,7 +20,6 @@ import base.TestMessageData.{allOptionsNoneJsonValue, consignment}
 import base.{SpecBase, TestMessageData}
 import generators.Generators
 import models.messages.MessageData
-import models.reference.transport.border.active.Identification
 import models.reference.{CustomsOffice, Nationality}
 import models.{Mode, UserAnswers}
 import org.mockito.ArgumentMatchers.any
@@ -105,7 +104,7 @@ class ActiveBorderTransportMeansAnswersHelperSpec extends SpecBase with ScalaChe
                 UserAnswers(departureId, eoriNumber, lrn.value, Json.obj(), Instant.now(), allOptionsNoneJsonValue.as[MessageData])
               val helper = new ActiveBorderTransportMeansAnswersHelper(noIdentificationTypeUserAnswers, departureId, refDataService, mode, activeIndex)
               val result = helper.identificationType
-              result.futureValue mustBe None
+              result mustBe None
           }
         }
       }
@@ -118,35 +117,10 @@ class ActiveBorderTransportMeansAnswersHelperSpec extends SpecBase with ScalaChe
                 .setValue(IdentificationPage(activeIndex), identification)
               val helper = new ActiveBorderTransportMeansAnswersHelper(answers, departureId, refDataService, mode, activeIndex)
 
-              whenReady[Option[SummaryListRow], Assertion](helper.identificationType) {
-                optionResult =>
-                  val result = optionResult.get
-
+              helper.identificationType.map {
+                result =>
                   result.key.value mustBe s"Identification type"
                   result.value.value mustBe identification.asString
-                  val actions = result.actions.get.items
-                  actions.size mustBe 1
-                  val action = actions.head
-                  action.content.value mustBe "Change"
-                  action.href mustBe controllers.transport.border.active.routes.IdentificationController.onPageLoad(departureId, mode, activeIndex).url
-                  action.visuallyHiddenText.get mustBe "identification type for the border means of transport"
-                  action.id mustBe "change-identification"
-              }
-          }
-        }
-
-        s"when $IdentificationPage defined in the ie13/15" in {
-          forAll(arbitrary[Mode], arbitrary[UserAnswers]) {
-            (mode, answers) =>
-              val code = answers.departureData.Consignment.ActiveBorderTransportMeans.flatMap(_.head.typeOfIdentification).get
-              when(refDataService.getBorderMeansIdentification(any())(any())).thenReturn(Future.successful(Identification(code, "description")))
-              val helper = new ActiveBorderTransportMeansAnswersHelper(answers, departureId, refDataService, mode, activeIndex)
-
-              whenReady[Option[SummaryListRow], Assertion](helper.identificationType) {
-                optionResult =>
-                  val result = optionResult.get
-                  result.key.value mustBe s"Identification type"
-                  result.value.value mustBe messages(s"${Identification.messageKeyPrefix}.$code")
                   val actions = result.actions.get.items
                   actions.size mustBe 1
                   val action = actions.head
@@ -186,24 +160,6 @@ class ActiveBorderTransportMeansAnswersHelperSpec extends SpecBase with ScalaChe
 
               result.key.value mustBe s"Identification number"
               result.value.value mustBe identificationNumber
-              val actions = result.actions.get.items
-              actions.size mustBe 1
-              val action = actions.head
-              action.content.value mustBe "Change"
-              action.href mustBe controllers.transport.border.active.routes.IdentificationNumberController.onPageLoad(departureId, mode, activeIndex).url
-              action.visuallyHiddenText.get mustBe "identification number for the border means of transport"
-              action.id mustBe "change-identification-number"
-          }
-        }
-
-        s"when $IdentificationNumberPage defined in the ie13/15" in {
-          forAll(arbitrary[Mode], arbitrary[UserAnswers]) {
-            (mode, answers) =>
-              val helper = new ActiveBorderTransportMeansAnswersHelper(answers, departureId, refDataService, mode, activeIndex)
-              val result = helper.identificationNumber.get
-
-              result.key.value mustBe s"Identification number"
-              result.value.value mustBe "BX857GGE"
               val actions = result.actions.get.items
               actions.size mustBe 1
               val action = actions.head

--- a/test/utils/transformer/IdentificationNumberTransformerTest.scala
+++ b/test/utils/transformer/IdentificationNumberTransformerTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.transformer
+
+import base.SpecBase
+import base.TestMessageData.activeBorderTransportMeansIdentificationNumber
+import models.Index
+import pages.transport.border.active.IdentificationNumberPage
+
+class IdentificationNumberTransformerTest extends SpecBase {
+
+  "IdentificationTransformer" - {
+    "fromDepartureDataToUserAnswers" - {
+      "must return updated answers if the update is successful" in {
+        val identificationNumber = activeBorderTransportMeansIdentificationNumber
+
+        val userAnswers = emptyUserAnswers
+        val index       = Index(0)
+        userAnswers.get(IdentificationNumberPage(index)) mustBe None
+
+        val updatedUserAnswers = IdentificationNumberTransformer.fromDepartureDataToUserAnswers(userAnswers).get
+        updatedUserAnswers.get(IdentificationNumberPage(index)) mustBe Some(identificationNumber)
+      }
+    }
+  }
+}

--- a/test/utils/transformer/IdentificationTransformerTest.scala
+++ b/test/utils/transformer/IdentificationTransformerTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.transformer
+
+import base.SpecBase
+import base.TestMessageData.activeBorderTransportMeansIdentification
+import models.Index
+import models.reference.transport.border.active.Identification
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.Assertion
+import pages.transport.border.active.IdentificationPage
+import services.MeansOfTransportIdentificationTypesActiveService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class IdentificationTransformerTest extends SpecBase {
+  private val service = mock[MeansOfTransportIdentificationTypesActiveService]
+  val transformer     = new IdentificationTransformer(service)
+
+  override def beforeEach() =
+    reset(service)
+
+  "IdentificationTransformer" - {
+    "fromDepartureDataToUserAnswers" - {
+      "must return updated answers when the code from departure data can be found in service response" in {
+        val identification = Identification(activeBorderTransportMeansIdentification, "description")
+        when(service.getMeansOfTransportIdentificationTypesActive).thenReturn(Future.successful(Seq(identification)))
+
+        val userAnswers = emptyUserAnswers
+        val index       = Index(0)
+        userAnswers.get(IdentificationPage(index)) mustBe None
+
+        whenReady(transformer.fromDepartureDataToUserAnswers(userAnswers)) {
+          updatedUserAnswers =>
+            updatedUserAnswers.get(IdentificationPage(index)) mustBe Some(identification)
+        }
+      }
+    }
+
+    "must return None when the code from departure data cannot be found in service response" in {
+      val identification = Identification("something else", "description")
+      when(service.getMeansOfTransportIdentificationTypesActive).thenReturn(Future.successful(Seq(identification)))
+
+      val userAnswers = emptyUserAnswers
+      val index       = Index(0)
+      userAnswers.get(IdentificationPage(index)) mustBe None
+
+      whenReady(transformer.fromDepartureDataToUserAnswers(userAnswers)) {
+        updatedUserAnswers =>
+          updatedUserAnswers.get(IdentificationPage(index)) mustBe None
+      }
+    }
+
+    "must return failure if the service fails" in {
+      when(service.getMeansOfTransportIdentificationTypesActive).thenReturn(Future.failed(new RuntimeException("")))
+
+      val userAnswers = emptyUserAnswers
+      val index       = Index(0)
+      userAnswers.get(IdentificationPage(index)) mustBe None
+
+      whenReady[Throwable, Assertion](transformer.fromDepartureDataToUserAnswers(userAnswers).failed) {
+        _ mustBe an[Exception]
+      }
+    }
+  }
+}

--- a/test/viewModels/transport/border/active/ActiveBorderAnswersViewModelSpec.scala
+++ b/test/viewModels/transport/border/active/ActiveBorderAnswersViewModelSpec.scala
@@ -328,7 +328,7 @@ class ActiveBorderAnswersViewModelSpec extends SpecBase with ScalaCheckPropertyC
             .futureValue
             .section
 
-          ie15ActiveBorderSection.rows.size mustBe 7
+          ie15ActiveBorderSection.rows.size mustBe 5
           ie15ActiveBorderSection.sectionTitle mustBe Some("Border means of transport 1")
           ie15ActiveBorderSection.sectionTitle mustBe defined
           ie15ActiveBorderSection.addAnotherLink mustBe defined


### PR DESCRIPTION
**Jira:** Bug no: 7 in https://jira.tools.tax.service.gov.uk/browse/CTCP-4669

See the screenshots below:
| CYA | Add Another |
| --- | --- |
| <img width="550" alt="image" src="https://github.com/hmrc/ctc-presentation-notification-frontend/assets/1747145/df77b49d-6779-48ec-ae1e-0665c5194c93">| <img width="637" alt="image" src="https://github.com/hmrc/ctc-presentation-notification-frontend/assets/1747145/61e52e17-17f9-4629-9a4d-a0ec46537c68">|

### **Problems:**

Current:
- We pull the items from IE015 departure data and display in CYA page
- When we navigate to Add Another ... page we only display user answers from IE170, therefore display 0 border means of transport

If _Displaying Departure Data and User Answers together:_
- We cannot directly add new items as in this example when we already have 2 items from IE015, the item from IE170 will have index of 3 but the list in UserAnswers will not allow it to be added with index 3 since the list size is 0
- Requires index calculation for IE170 items in multiple places which is complex and error-prone
- We need to have **Change** and **Remove** links for each items in this list which don't work
- We don't want to modify IE015 data with change or remove IE015 data as it's our initial source of truth

### Solution:
- On application load for the departure, transform IE015 departure data into IE170 user answers
- Keep IE015 untouched
- Allow change/remove the items since they are now IE170 data, although originally come from IE015  departure data
- Rely on IE170 data only in controller, navigator and CYA answers

<img width="729" alt="image" src="https://github.com/hmrc/ctc-presentation-notification-frontend/assets/1747145/dd945f1b-b09b-4305-8bae-4d9664b0d015">


