### PR TITLE
CTCP-5329

### DIFF
--- a/app/controllers/locationOfGoods/IdentificationController.scala
+++ b/app/controllers/locationOfGoods/IdentificationController.scala
@@ -51,15 +51,13 @@ class IdentificationController @Inject() (
     .requireData(departureId)
     .async {
       implicit request =>
-        val ie170Identification = request.userAnswers.get(IdentificationPage)
-
         getLocationType match {
           case Some(location) =>
             locationOfGoodsIdentificationTypeService.getLocationOfGoodsIdentificationTypes(location).flatMap {
               case identifier :: Nil =>
                 redirect(mode, InferredIdentificationPage, identifier, departureId)
               case identifiers =>
-                val preparedForm = ie170Identification match {
+                val preparedForm = request.userAnswers.get(IdentificationPage) match {
                   case None        => form(identifiers)
                   case Some(value) => form(identifiers).fill(value)
                 }
@@ -85,14 +83,10 @@ class IdentificationController @Inject() (
     } yield Redirect(navigator.nextPage(page, updatedAnswers, departureId, mode))
 
   private def getLocationType(implicit request: DataRequest[AnyContent]): Option[String] =
-    request.userAnswers
-      .get(LocationTypePage)
-      .map(_.`type`)
-      .orElse(
-        request.userAnswers
-          .get(InferredLocationTypePage)
-          .map(_.`type`)
-      )
+    (
+      request.userAnswers.get(LocationTypePage) orElse
+        request.userAnswers.get(InferredLocationTypePage)
+    ).map(_.`type`)
 
   def onSubmit(departureId: String, mode: Mode): Action[AnyContent] = actions
     .requireData(departureId)

--- a/app/navigation/BorderNavigator.scala
+++ b/app/navigation/BorderNavigator.scala
@@ -153,18 +153,16 @@ class BorderNavigator extends Navigator {
     }
 
   private def addConveyanceNavigation(ua: UserAnswers, departureId: String, mode: Mode, activeIndex: Index): Option[Call] =
-    ua.get(AddConveyanceReferenceYesNoPage(activeIndex)) match {
-      case Some(true)  => ConveyanceReferenceNumberPage(activeIndex).route(ua, departureId, mode)
-      case Some(false) => redirectToAddAnotherActiveBorderNavigation(ua, departureId, mode)
-      case _           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(AddConveyanceReferenceYesNoPage(activeIndex)) flatMap {
+      case true  => ConveyanceReferenceNumberPage(activeIndex).route(ua, departureId, mode)
+      case false => redirectToAddAnotherActiveBorderNavigation(ua, departureId, mode)
     }
 
   private def addAnotherBorderNavigation(ua: UserAnswers, departureId: String, mode: Mode, activeIndex: Index): Option[Call] =
-    ua.get(AddAnotherBorderMeansOfTransportYesNoPage(activeIndex)) match {
-      case Some(true)                       => Some(routes.IdentificationController.onPageLoad(departureId, mode, activeIndex))
-      case Some(false) if mode == CheckMode => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-      case Some(false)                      => containerIndicatorRouting(ua, departureId, mode)
-      case _                                => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(AddAnotherBorderMeansOfTransportYesNoPage(activeIndex)) flatMap {
+      case true                       => Some(routes.IdentificationController.onPageLoad(departureId, mode, activeIndex))
+      case false if mode == CheckMode => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+      case false                      => containerIndicatorRouting(ua, departureId, mode)
     }
 
   private def redirectToAddAnotherActiveBorderNavigation(ua: UserAnswers, departureId: String, mode: Mode): Option[Call] =

--- a/app/navigation/BorderNavigator.scala
+++ b/app/navigation/BorderNavigator.scala
@@ -178,23 +178,20 @@ class BorderNavigator extends Navigator {
 
 object BorderNavigator {
 
-  private[navigation] def borderModeOfTransportPageNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] = {
-
-    val numberOfActiveBorderMeans: Int = userAnswers.get(BorderActiveListSection).map(_.value.length - 1).getOrElse(0)
-
-    if (userAnswers.departureData.Consignment.ActiveBorderTransportMeans.isEmpty && userAnswers.departureData.hasSecurity)
+  private[navigation] def borderModeOfTransportPageNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
+    if (userAnswers.departureData.Consignment.ActiveBorderTransportMeans.isEmpty && userAnswers.departureData.hasSecurity) {
+      val numberOfActiveBorderMeans: Int = userAnswers.get(BorderActiveListSection).map(_.value.length - 1).getOrElse(0)
       transport.border.active.IdentificationPage(Index(numberOfActiveBorderMeans)).route(userAnswers, departureId, mode)
-    else containerIndicatorRouting(userAnswers, departureId, mode)
-  }
+    } else {
+      containerIndicatorRouting(userAnswers, departureId, mode)
+    }
 
   private[navigation] def containerIndicatorRouting(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
     if (userAnswers.departureData.Consignment.containerIndicator.isDefined) {
       Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
     } else {
       userAnswers.get(ContainerIndicatorPage) match {
-        case Some(true) =>
-          ContainerIdentificationNumberPage(Index(0))
-            .route(userAnswers, departureId, mode)
+        case Some(true)  => ContainerIdentificationNumberPage(Index(0)).route(userAnswers, departureId, mode)
         case Some(false) => AddTransportEquipmentYesNoPage.route(userAnswers, departureId, mode)
         case None        => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
       }

--- a/app/navigation/BorderNavigator.scala
+++ b/app/navigation/BorderNavigator.scala
@@ -35,7 +35,6 @@ import play.api.mvc.Call
 class BorderNavigator extends Navigator {
 
   override def normalRoutes(departureId: String, mode: Mode): PartialFunction[Page, UserAnswers => Option[Call]] = {
-
     case BorderModeOfTransportPage                              => ua => borderModeOfTransportPageNavigation(ua, departureId, mode)
     case IdentificationPage(activeIndex)                        => ua => IdentificationNumberPage(activeIndex).route(ua, departureId, mode)
     case IdentificationNumberPage(activeIndex)                  => ua => NationalityPage(activeIndex).route(ua, departureId, mode)
@@ -83,10 +82,9 @@ class BorderNavigator extends Navigator {
   private def addInlandModeYesNoCheckRoute(ua: UserAnswers, departureId: String): Option[Call] =
     ua.get(AddInlandModeOfTransportYesNoPage) match {
       case Some(true) =>
-        val ie015InlandMode = ua.departureData.Consignment.inlandModeOfTransport
-        (ua.get(InlandModePage), ie015InlandMode) match {
-          case (None, None) => Some(controllers.transport.routes.InlandModeController.onPageLoad(departureId, CheckMode))
-          case _            => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+        ua.get(InlandModePage) match {
+          case None => Some(controllers.transport.routes.InlandModeController.onPageLoad(departureId, CheckMode))
+          case _    => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
         }
       case _ => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
     }
@@ -129,10 +127,10 @@ class BorderNavigator extends Navigator {
         }
     }
 
-  private def borderModeOfTransportAlreadyAnswered(ua: UserAnswers, departureId: String) =
-    (ua.get(BorderModeOfTransportPage), ua.departureData.Consignment.modeOfTransportAtTheBorder) match {
-      case (None, None) => BorderModeOfTransportPage.route(ua, departureId, CheckMode)
-      case _            => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+  private def borderModeOfTransportAlreadyAnswered(ua: UserAnswers, departureId: String): Option[Call] =
+    ua.get(BorderModeOfTransportPage) match {
+      case None => BorderModeOfTransportPage.route(ua, departureId, CheckMode)
+      case _    => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
     }
 
   private def customsOfficeNavigation(ua: UserAnswers, departureId: String, mode: Mode, activeIndex: Index): Option[Call] =
@@ -169,10 +167,7 @@ class BorderNavigator extends Navigator {
     if (ua.departureData.CustomsOfficeOfTransitDeclared.nonEmpty) {
       Some(routes.AddAnotherBorderMeansOfTransportYesNoController.onPageLoad(departureId, mode))
     } else {
-      ua.get(ContainerIndicatorPage) match {
-        case Some(_) => containerIndicatorRouting(ua, departureId, mode)
-        case None    => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-      }
+      containerIndicatorRouting(ua, departureId, mode)
     }
 }
 

--- a/app/navigation/CommonNavigation.scala
+++ b/app/navigation/CommonNavigation.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import models.{CheckMode, Index, Mode, NormalMode, RichCC015CType, UserAnswers}
+import pages.sections.transport.border.BorderActiveListSection
+import pages.transport
+import pages.transport.border.BorderModeOfTransportPage
+import pages.transport.equipment.AddTransportEquipmentYesNoPage
+import pages.transport.equipment.index.ContainerIdentificationNumberPage
+import pages.transport.{ContainerIndicatorPage, LimitDatePage}
+import play.api.mvc.Call
+
+trait CommonNavigation {
+
+  protected def borderModeOfTransportPageNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
+    if (userAnswers.departureData.Consignment.ActiveBorderTransportMeans.isEmpty && userAnswers.departureData.hasSecurity) {
+      val numberOfActiveBorderMeans: Int = userAnswers.get(BorderActiveListSection).map(_.value.length - 1).getOrElse(0)
+      transport.border.active.IdentificationPage(Index(numberOfActiveBorderMeans)).route(userAnswers, departureId, mode)
+    } else {
+      containerIndicatorCapturedNavigation(userAnswers, departureId, mode)
+    }
+
+  protected def containerIndicatorCapturedNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
+    if (userAnswers.departureData.Consignment.containerIndicator.isDefined) {
+      Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+    } else {
+      userAnswers.get(ContainerIndicatorPage) match {
+        case Some(true)  => ContainerIdentificationNumberPage(Index(0)).route(userAnswers, departureId, mode)
+        case Some(false) => AddTransportEquipmentYesNoPage.route(userAnswers, departureId, mode)
+        case None        => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+      }
+    }
+
+  protected def containerIndicatorPageNavigation(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
+    if (ua.departureData.hasSecurity)
+      BorderModeOfTransportPage.route(ua, departureId, mode)
+    else
+      borderModeOfTransportPageNavigation(ua, departureId, mode)
+
+  protected def locationPageNavigation(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
+    if (ua.departureData.isSimplified && isLimitDateMissing(ua, mode)) {
+      LimitDatePage.route(ua, departureId, mode)
+    } else {
+      limitDatePageNavigation(departureId, mode, ua)
+    }
+
+  protected def limitDatePageNavigation(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
+    if (isContainerIndicatorMissing(ua, mode)) {
+      ContainerIndicatorPage.route(ua, departureId, mode)
+    } else {
+      containerIndicatorPageNavigation(departureId, mode, ua)
+    }
+
+  private def isContainerIndicatorMissing(ua: UserAnswers, mode: Mode): Boolean =
+    mode match {
+      case NormalMode => ua.departureData.Consignment.containerIndicator.isEmpty
+      case CheckMode  => ua.get(ContainerIndicatorPage).isEmpty
+    }
+
+  private def isLimitDateMissing(ua: UserAnswers, mode: Mode): Boolean =
+    mode match {
+      case NormalMode => ua.departureData.TransitOperation.limitDate.isEmpty
+      case CheckMode  => ua.get(LimitDatePage).isEmpty
+    }
+}

--- a/app/navigation/ContainerNavigator.scala
+++ b/app/navigation/ContainerNavigator.scala
@@ -45,9 +45,8 @@ class ContainerNavigator @Inject() () extends Navigator {
   }
 
   private def containerIndicatorCheckRoute(ua: UserAnswers, departureId: String, mode: Mode): Option[Call] =
-    ua.get(ContainerIndicatorPage) match {
-      case Some(true)  => Some(controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, Index(0)))
-      case Some(false) => Some(controllers.transport.equipment.routes.AddTransportEquipmentYesNoController.onPageLoad(departureId, mode))
-      case None        => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(ContainerIndicatorPage) map {
+      case true  => controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, Index(0))
+      case false => controllers.transport.equipment.routes.AddTransportEquipmentYesNoController.onPageLoad(departureId, mode)
     }
 }

--- a/app/navigation/ContainerNavigator.scala
+++ b/app/navigation/ContainerNavigator.scala
@@ -18,11 +18,8 @@ package navigation
 
 import com.google.inject.Singleton
 import models._
-import navigation.BorderNavigator.borderModeOfTransportPageNavigation
-import navigation.ContainerNavigator.containerIndicatorPageNavigation
 import pages._
 import pages.transport.ContainerIndicatorPage
-import pages.transport.border._
 import play.api.mvc.Call
 
 import javax.inject.Inject
@@ -43,13 +40,4 @@ class ContainerNavigator @Inject() () extends Navigator {
       case true  => controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, Index(0))
       case false => controllers.transport.equipment.routes.AddTransportEquipmentYesNoController.onPageLoad(departureId, mode)
     }
-}
-
-object ContainerNavigator {
-
-  def containerIndicatorPageNavigation(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
-    if (ua.departureData.hasSecurity)
-      BorderModeOfTransportPage.route(ua, departureId, mode)
-    else
-      borderModeOfTransportPageNavigation(ua, departureId, mode)
 }

--- a/app/navigation/ContainerNavigator.scala
+++ b/app/navigation/ContainerNavigator.scala
@@ -19,6 +19,7 @@ package navigation
 import com.google.inject.Singleton
 import models._
 import navigation.BorderNavigator.borderModeOfTransportPageNavigation
+import navigation.ContainerNavigator.containerIndicatorPageNavigation
 import pages._
 import pages.transport.ContainerIndicatorPage
 import pages.transport.border._
@@ -30,15 +31,8 @@ import javax.inject.Inject
 class ContainerNavigator @Inject() () extends Navigator {
 
   override def normalRoutes(departureId: String, mode: Mode): PartialFunction[Page, UserAnswers => Option[Call]] = {
-    case ContainerIndicatorPage => ua => containerIndicatorNavigation(ua, departureId, mode)
+    case ContainerIndicatorPage => ua => containerIndicatorPageNavigation(departureId, mode, ua)
   }
-
-  private def containerIndicatorNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
-    if (checkTransitOperationSecurity(userAnswers)) BorderModeOfTransportPage.route(userAnswers, departureId, mode)
-    else borderModeOfTransportPageNavigation(userAnswers, departureId, mode)
-
-  private def checkTransitOperationSecurity(ua: UserAnswers): Boolean =
-    ua.departureData.hasSecurity
 
   override def checkRoutes(departureId: String, mode: Mode): PartialFunction[Page, UserAnswers => Option[Call]] = {
     case ContainerIndicatorPage => ua => containerIndicatorCheckRoute(ua, departureId, mode)
@@ -49,4 +43,13 @@ class ContainerNavigator @Inject() () extends Navigator {
       case true  => controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, Index(0))
       case false => controllers.transport.equipment.routes.AddTransportEquipmentYesNoController.onPageLoad(departureId, mode)
     }
+}
+
+object ContainerNavigator {
+
+  def containerIndicatorPageNavigation(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
+    if (ua.departureData.hasSecurity)
+      BorderModeOfTransportPage.route(ua, departureId, mode)
+    else
+      borderModeOfTransportPageNavigation(ua, departureId, mode)
 }

--- a/app/navigation/DepartureTransportMeansNavigator.scala
+++ b/app/navigation/DepartureTransportMeansNavigator.scala
@@ -43,13 +43,11 @@ class DepartureTransportMeansNavigator @Inject() () extends Navigator {
   }
 
   override def checkRoutes(departureId: String, mode: Mode): PartialFunction[Page, UserAnswers => Option[Call]] = {
-
     case TransportMeansIdentificationPage(transportIndex)       => ua => transportMeansIdentificationNavigation(ua, departureId, mode, transportIndex)
     case TransportMeansIdentificationNumberPage(transportIndex) => ua => transportMeansNumberNavigation(ua, departureId, mode, transportIndex)
     case TransportMeansNationalityPage(_) =>
       _ => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
     case AddAnotherTransportMeansPage(transportIndex) => ua => addAnotherTransportMeansNavigation(ua, departureId, transportIndex)
-
   }
 
   private def transportMeansIdentificationNavigation(ua: UserAnswers, departureId: String, mode: Mode, transportIndex: Index): Option[Call] =

--- a/app/navigation/DepartureTransportMeansNavigator.scala
+++ b/app/navigation/DepartureTransportMeansNavigator.scala
@@ -66,11 +66,11 @@ class DepartureTransportMeansNavigator @Inject() () extends Navigator {
     }
 
   private def addAnotherTransportMeansNavigation(ua: UserAnswers, departureId: String, transportIndex: Index): Option[Call] =
-    ua.get(AddAnotherTransportMeansPage(transportIndex)) match {
-      case Some(true) =>
-        Some(controllers.transport.departureTransportMeans.routes.TransportMeansIdentificationController.onPageLoad(departureId, NormalMode, transportIndex))
-      case Some(false) => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-      case _           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(AddAnotherTransportMeansPage(transportIndex)) map {
+      case true =>
+        controllers.transport.departureTransportMeans.routes.TransportMeansIdentificationController.onPageLoad(departureId, NormalMode, transportIndex)
+      case false =>
+        controllers.routes.CheckYourAnswersController.onPageLoad(departureId)
     }
 
 }

--- a/app/navigation/EquipmentNavigator.scala
+++ b/app/navigation/EquipmentNavigator.scala
@@ -65,23 +65,20 @@ class EquipmentNavigator extends Navigator {
     }
 
   private def applyAnotherItemRoute(ua: UserAnswers, departureId: String, mode: Mode, equipmentIndex: Index, itemIndex: Index): Option[Call] =
-    ua.get(ApplyAnotherItemPage(equipmentIndex, itemIndex)) match {
-      case Some(true)                  => ItemPage(equipmentIndex, itemIndex).route(ua, departureId, mode)
-      case Some(false) if mode.isCheck => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-      case Some(false)                 => Some(controllers.transport.equipment.routes.AddAnotherEquipmentController.onPageLoad(departureId, mode))
-      case _                           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(ApplyAnotherItemPage(equipmentIndex, itemIndex)) flatMap {
+      case true                  => ItemPage(equipmentIndex, itemIndex).route(ua, departureId, mode)
+      case false if mode.isCheck => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+      case false                 => Some(controllers.transport.equipment.routes.AddAnotherEquipmentController.onPageLoad(departureId, mode))
     }
 
   private def addContainerIdentificationNumberYesNoRoute(ua: UserAnswers, equipmentIndex: Index, departureId: String, mode: Mode): Option[Call] =
-    ua.get(AddContainerIdentificationNumberYesNoPage(equipmentIndex)) match {
-      case Some(true) =>
-        Some(controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex))
-      case Some(false) if ua.departureData.isSimplified && ua.departureData.hasAuthC523 =>
-        Some(controllers.transport.equipment.index.seals.routes.SealIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex, Index(0)))
-      case Some(false) =>
-        Some(controllers.transport.equipment.index.routes.AddSealYesNoController.onPageLoad(departureId, mode, equipmentIndex))
-      case _ =>
-        Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(AddContainerIdentificationNumberYesNoPage(equipmentIndex)) map {
+      case true =>
+        controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex)
+      case false if ua.departureData.isSimplified && ua.departureData.hasAuthC523 =>
+        controllers.transport.equipment.index.seals.routes.SealIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex, Index(0))
+      case false =>
+        controllers.transport.equipment.index.routes.AddSealYesNoController.onPageLoad(departureId, mode, equipmentIndex)
     }
 
   private def addContainerIdentificationNumberYesNoCheckRoute(ua: UserAnswers, equipmentIndex: Index, departureId: String, mode: Mode): Option[Call] =
@@ -100,11 +97,10 @@ class EquipmentNavigator extends Navigator {
     }
 
   private def addSealYesNoNormalRoute(ua: UserAnswers, departureId: String, mode: Mode, equipmentIndex: Index): Option[Call] =
-    ua.get(AddSealYesNoPage(equipmentIndex)) match {
-      case Some(true)                  => SealIdentificationNumberPage(equipmentIndex, Index(0)).route(ua, departureId, mode)
-      case Some(false) if mode.isCheck => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-      case Some(false)                 => ItemPage(equipmentIndex, Index(0)).route(ua, departureId, mode)
-      case _                           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(AddSealYesNoPage(equipmentIndex)) flatMap {
+      case true                  => SealIdentificationNumberPage(equipmentIndex, Index(0)).route(ua, departureId, mode)
+      case false if mode.isCheck => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+      case false                 => ItemPage(equipmentIndex, Index(0)).route(ua, departureId, mode)
     }
 
   private def checkProcedureAuthRoute(ua: UserAnswers, departureId: String, mode: Mode, equipmentIndex: Index): Option[Call] =
@@ -115,11 +111,10 @@ class EquipmentNavigator extends Navigator {
     }
 
   def addAnotherSealRoute(ua: UserAnswers, departureId: String, mode: Mode, equipmentIndex: Index, sealIndex: Index): Option[Call] =
-    ua.get(AddAnotherSealPage(equipmentIndex, sealIndex)) match {
-      case Some(true)                  => SealIdentificationNumberPage(equipmentIndex, sealIndex).route(ua, departureId, mode)
-      case Some(false) if mode.isCheck => addAnotherSealCheckRoute(ua: UserAnswers, departureId: String, mode: Mode, equipmentIndex: Index)
-      case Some(false)                 => ItemPage(equipmentIndex, Index(0)).route(ua, departureId, mode)
-      case _                           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(AddAnotherSealPage(equipmentIndex, sealIndex)) flatMap {
+      case true                  => SealIdentificationNumberPage(equipmentIndex, sealIndex).route(ua, departureId, mode)
+      case false if mode.isCheck => addAnotherSealCheckRoute(ua: UserAnswers, departureId: String, mode: Mode, equipmentIndex: Index)
+      case false                 => ItemPage(equipmentIndex, Index(0)).route(ua, departureId, mode)
     }
 
   def addAnotherSealCheckRoute(ua: UserAnswers, departureId: String, mode: Mode, equipmentIndex: Index): Option[Call] =
@@ -135,18 +130,17 @@ class EquipmentNavigator extends Navigator {
     }
 
   private def addAnotherTransportEquipmentRoute(ua: UserAnswers, equipmentIndex: Index, departureId: String, mode: Mode): Option[Call] =
-    ua.get(AddAnotherTransportEquipmentPage(equipmentIndex)) match {
-      case Some(true) =>
+    ua.get(AddAnotherTransportEquipmentPage(equipmentIndex)) map {
+      case true =>
         ua.get(ContainerIndicatorPage) match {
           case Some(true) =>
-            Some(
-              controllers.transport.equipment.index.routes.AddContainerIdentificationNumberYesNoController.onPageLoad(departureId, mode, equipmentIndex)
-            )
+            controllers.transport.equipment.index.routes.AddContainerIdentificationNumberYesNoController.onPageLoad(departureId, mode, equipmentIndex)
           case _ if ua.departureData.isSimplified && ua.departureData.hasAuthC523 =>
-            Some(controllers.transport.equipment.index.seals.routes.SealIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex, Index(0)))
-          case _ => Some(controllers.transport.equipment.index.routes.AddSealYesNoController.onPageLoad(departureId, mode, equipmentIndex))
+            controllers.transport.equipment.index.seals.routes.SealIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex, Index(0))
+          case _ =>
+            controllers.transport.equipment.index.routes.AddSealYesNoController.onPageLoad(departureId, mode, equipmentIndex)
         }
-      case Some(false) => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-      case _           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+      case false =>
+        controllers.routes.CheckYourAnswersController.onPageLoad(departureId)
     }
 }

--- a/app/navigation/LoadingNavigator.scala
+++ b/app/navigation/LoadingNavigator.scala
@@ -18,11 +18,10 @@ package navigation
 
 import com.google.inject.Singleton
 import models._
-import navigation.BorderNavigator._
 import navigation.LoadingNavigator._
+import navigation.LocationOfGoodsNavigator.limitDatePageNavigator
 import pages.Page
 import pages.loading._
-import pages.transport.border.BorderModeOfTransportPage
 import pages.transport.{ContainerIndicatorPage, LimitDatePage}
 import play.api.mvc.Call
 
@@ -93,19 +92,13 @@ object LoadingNavigator {
       if (isLimitDateMissing(ua, mode)) {
         LimitDatePage.route(ua, departureId, mode)
       } else {
-        if (isContainerIndicatorMissing(ua, mode)) {
-          ContainerIndicatorPage.route(ua, departureId, mode)
-        } else {
-          containerIndicatorPageNavigation(departureId, mode, ua)
-        }
+        limitDatePageNavigator(departureId, mode, ua)
       }
-    } else if (isContainerIndicatorMissing(ua, mode)) {
-      ContainerIndicatorPage.route(ua, departureId, mode)
     } else {
-      containerIndicatorPageNavigation(departureId, mode, ua)
+      limitDatePageNavigator(departureId, mode, ua)
     }
 
-  private def isContainerIndicatorMissing(ua: UserAnswers, mode: Mode) =
+  def isContainerIndicatorMissing(ua: UserAnswers, mode: Mode): Boolean =
     mode match {
       case NormalMode => ua.departureData.Consignment.containerIndicator.isEmpty
       case CheckMode  => ua.get(ContainerIndicatorPage).isEmpty
@@ -116,11 +109,4 @@ object LoadingNavigator {
       case NormalMode => ua.departureData.TransitOperation.limitDate.isEmpty
       case CheckMode  => ua.get(LimitDatePage).isEmpty
     }
-
-  private[navigation] def containerIndicatorPageNavigation(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
-    if (ua.departureData.hasSecurity)
-      BorderModeOfTransportPage.route(ua, departureId, mode)
-    else
-      borderModeOfTransportPageNavigation(ua, departureId, mode)
-
 }

--- a/app/navigation/LoadingNavigator.scala
+++ b/app/navigation/LoadingNavigator.scala
@@ -69,11 +69,9 @@ class LoadingNavigator extends Navigator {
     }
 
   private def addExtraInformationYesNoNormalRoute(ua: UserAnswers, departureId: String): Option[Call] =
-    ua.get(AddExtraInformationYesNoPage) match {
-      case Some(true) =>
-        CountryPage.route(ua, departureId, NormalMode)
-      case Some(false) => locationPageNavigation(departureId, NormalMode, ua)
-      case _           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    ua.get(AddExtraInformationYesNoPage) flatMap {
+      case true  => CountryPage.route(ua, departureId, NormalMode)
+      case false => locationPageNavigation(departureId, NormalMode, ua)
     }
 
   private def addExtraInformationYesNoCheckRoute(ua: UserAnswers, departureId: String): Option[Call] =

--- a/app/navigation/LoadingNavigator.scala
+++ b/app/navigation/LoadingNavigator.scala
@@ -18,11 +18,8 @@ package navigation
 
 import com.google.inject.Singleton
 import models._
-import navigation.LoadingNavigator._
-import navigation.LocationOfGoodsNavigator.limitDatePageNavigator
 import pages.Page
 import pages.loading._
-import pages.transport.{ContainerIndicatorPage, LimitDatePage}
 import play.api.mvc.Call
 
 @Singleton
@@ -82,31 +79,5 @@ class LoadingNavigator extends Navigator {
 
         }
       case _ => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-    }
-}
-
-object LoadingNavigator {
-
-  private[navigation] def locationPageNavigation(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
-    if (ua.departureData.isSimplified) {
-      if (isLimitDateMissing(ua, mode)) {
-        LimitDatePage.route(ua, departureId, mode)
-      } else {
-        limitDatePageNavigator(departureId, mode, ua)
-      }
-    } else {
-      limitDatePageNavigator(departureId, mode, ua)
-    }
-
-  def isContainerIndicatorMissing(ua: UserAnswers, mode: Mode): Boolean =
-    mode match {
-      case NormalMode => ua.departureData.Consignment.containerIndicator.isEmpty
-      case CheckMode  => ua.get(ContainerIndicatorPage).isEmpty
-    }
-
-  private def isLimitDateMissing(ua: UserAnswers, mode: Mode) =
-    mode match {
-      case NormalMode => ua.departureData.TransitOperation.limitDate.isEmpty
-      case CheckMode  => ua.get(LimitDatePage).isEmpty
     }
 }

--- a/app/navigation/LocationOfGoodsNavigator.scala
+++ b/app/navigation/LocationOfGoodsNavigator.scala
@@ -93,19 +93,17 @@ class LocationOfGoodsNavigator @Inject() () extends Navigator {
     }
 
   private def addIdentifierYesNoNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
-    userAnswers.get(AddIdentifierYesNoPage) match {
-      case Some(true)  => AdditionalIdentifierPage.route(userAnswers, departureId, mode)
-      case Some(false) => AddContactYesNoPage.route(userAnswers, departureId, mode)
-      case _           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+    userAnswers.get(AddIdentifierYesNoPage) flatMap {
+      case true  => AdditionalIdentifierPage.route(userAnswers, departureId, mode)
+      case false => AddContactYesNoPage.route(userAnswers, departureId, mode)
     }
 
   private def addContactYesNoNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
     mode match {
       case NormalMode =>
-        userAnswers.get(AddContactYesNoPage) match {
-          case Some(true)  => NamePage.route(userAnswers, departureId, mode)
-          case Some(false) => placeOfLoadingExistsRedirect(userAnswers, departureId, mode)
-          case _           => Some(controllers.routes.SessionExpiredController.onPageLoad())
+        userAnswers.get(AddContactYesNoPage) flatMap {
+          case true  => NamePage.route(userAnswers, departureId, mode)
+          case false => placeOfLoadingExistsRedirect(userAnswers, departureId, mode)
         }
       case CheckMode =>
         userAnswers.get(AddContactYesNoPage) match {

--- a/app/navigation/LocationOfGoodsNavigator.scala
+++ b/app/navigation/LocationOfGoodsNavigator.scala
@@ -114,12 +114,8 @@ class LocationOfGoodsNavigator @Inject() () extends Navigator {
 
   private def phoneNumberPageNavigation(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =
     mode match {
-      case NormalMode =>
-        userAnswers.departureData.Consignment.PlaceOfLoading match {
-          case Some(_) => placeOfLoadingExistsRedirect(userAnswers, departureId, mode)
-          case None    => AddUnLocodePage.route(userAnswers, departureId, mode)
-        }
-      case CheckMode => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
+      case NormalMode => placeOfLoadingExistsRedirect(userAnswers, departureId, mode)
+      case CheckMode  => Some(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
     }
 
   private def placeOfLoadingExistsRedirect(userAnswers: UserAnswers, departureId: String, mode: Mode): Option[Call] =

--- a/app/navigation/LocationOfGoodsNavigator.scala
+++ b/app/navigation/LocationOfGoodsNavigator.scala
@@ -19,7 +19,9 @@ package navigation
 import com.google.inject.Singleton
 import config.Constants.QualifierOfTheIdentification._
 import models._
+import navigation.ContainerNavigator.containerIndicatorPageNavigation
 import navigation.LoadingNavigator._
+import navigation.LocationOfGoodsNavigator.limitDatePageNavigator
 import pages._
 import pages.locationOfGoods._
 import pages.locationOfGoods.contact.{NamePage, PhoneNumberPage}
@@ -79,13 +81,6 @@ class LocationOfGoodsNavigator @Inject() () extends Navigator {
       case _                             => None
     }
 
-  private def limitDatePageNavigator(departureId: String, mode: Mode, ua: UserAnswers) =
-    ua.get(ContainerIndicatorPage) match {
-      case Some(_) =>
-        containerIndicatorPageNavigation(departureId, mode, ua)
-      case None => ContainerIndicatorPage.route(ua, departureId, mode)
-    }
-
   def locationOfGoodsNavigation(ua: UserAnswers, departureId: String, mode: Mode): Option[Call] =
     ua.departureData.Consignment.LocationOfGoods match {
       case None    => Some(controllers.locationOfGoods.routes.LocationTypeController.onPageLoad(departureId, mode))
@@ -122,5 +117,15 @@ class LocationOfGoodsNavigator @Inject() () extends Navigator {
     userAnswers.departureData.Consignment.PlaceOfLoading match {
       case Some(_) => locationPageNavigation(departureId, mode, userAnswers)
       case None    => AddUnLocodePage.route(userAnswers, departureId, mode)
+    }
+}
+
+object LocationOfGoodsNavigator {
+
+  def limitDatePageNavigator(departureId: String, mode: Mode, ua: UserAnswers): Option[Call] =
+    if (isContainerIndicatorMissing(ua, mode)) {
+      ContainerIndicatorPage.route(ua, departureId, mode)
+    } else {
+      containerIndicatorPageNavigation(departureId, mode, ua)
     }
 }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -22,7 +22,7 @@ import models.{CheckMode, Mode, NormalMode, UserAnswers}
 import pages.Page
 import play.api.mvc.Call
 
-trait Navigator extends Logging {
+trait Navigator extends CommonNavigation with Logging {
   private type RouteMapping = PartialFunction[Page, UserAnswers => Option[Call]]
 
   protected def normalRoutes(departureId: String, mode: Mode): RouteMapping

--- a/app/pages/transport/border/AddBorderModeOfTransportYesNoPage.scala
+++ b/app/pages/transport/border/AddBorderModeOfTransportYesNoPage.scala
@@ -36,8 +36,11 @@ case object AddBorderModeOfTransportYesNoPage extends QuestionPage[Boolean] {
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     value match {
-      case Some(false) => userAnswers.remove(BorderModeOfTransportPage)
-      case _           => super.cleanup(value, userAnswers)
+      case Some(false) =>
+        userAnswers
+          .remove(BorderModeOfTransportPage)
+      case _ =>
+        super.cleanup(value, userAnswers)
     }
 
 }

--- a/app/pages/transport/border/BorderModeOfTransportPage.scala
+++ b/app/pages/transport/border/BorderModeOfTransportPage.scala
@@ -39,11 +39,10 @@ case object BorderModeOfTransportPage extends QuestionPage[BorderMode] {
     value match {
       case Some(_) =>
         userAnswers
-          .remove(AddBorderMeansOfTransportYesNoPage)
-          .flatMap(
-            _.remove(IdentificationNumberPage(Index(0)))
-              .flatMap(_.remove(NationalityPage(Index(0))))
-          )
+          .set(AddBorderModeOfTransportYesNoPage, true)
+          .flatMap(_.remove(AddBorderMeansOfTransportYesNoPage))
+          .flatMap(_.remove(IdentificationNumberPage(Index(0))))
+          .flatMap(_.remove(NationalityPage(Index(0))))
 
       case _ => super.cleanup(value, userAnswers)
     }

--- a/app/pages/transport/border/BorderModeOfTransportPage.scala
+++ b/app/pages/transport/border/BorderModeOfTransportPage.scala
@@ -17,10 +17,10 @@
 package pages.transport.border
 
 import models.reference.TransportMode.BorderMode
-import models.{Index, Mode, UserAnswers}
+import models.{Mode, UserAnswers}
 import pages.QuestionPage
 import pages.sections.transport.TransportSection
-import pages.transport.border.active.{IdentificationNumberPage, NationalityPage}
+import pages.sections.transport.border.BorderActiveListSection
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -41,8 +41,7 @@ case object BorderModeOfTransportPage extends QuestionPage[BorderMode] {
         userAnswers
           .set(AddBorderModeOfTransportYesNoPage, true)
           .flatMap(_.remove(AddBorderMeansOfTransportYesNoPage))
-          .flatMap(_.remove(IdentificationNumberPage(Index(0))))
-          .flatMap(_.remove(NationalityPage(Index(0))))
+          .flatMap(_.remove(BorderActiveListSection))
 
       case _ => super.cleanup(value, userAnswers)
     }

--- a/app/utils/LocationOfGoodsAnswersHelper.scala
+++ b/app/utils/LocationOfGoodsAnswersHelper.scala
@@ -148,11 +148,11 @@ class LocationOfGoodsAnswersHelper(
       countryTypeRow,
       address,
       postCodeAddress,
+      additionalIdentifierYesNo,
+      additionalIdentifierRow,
       locationOfGoodsContactYesNo,
       locationOfGoodsContactPersonName,
-      locationOfGoodsContactPersonNumber,
-      if (authorisationNumber.isDefined | eoriNumber.isDefined) additionalIdentifierYesNo else None,
-      additionalIdentifierRow
+      locationOfGoodsContactPersonNumber
     ).flatten
 
     Section(

--- a/app/utils/transformer/locationOfGoods/IdentificationTransformer.scala
+++ b/app/utils/transformer/locationOfGoods/IdentificationTransformer.scala
@@ -17,7 +17,7 @@
 package utils.transformer.locationOfGoods
 
 import models.{LocationOfGoodsIdentification, UserAnswers}
-import pages.locationOfGoods.IdentificationPage
+import pages.locationOfGoods.{BaseIdentificationPage, IdentificationPage, InferredIdentificationPage}
 import services.LocationOfGoodsIdentificationTypeService
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.transformer.PageTransformer
@@ -42,14 +42,19 @@ class IdentificationTransformer @Inject() (service: LocationOfGoodsIdentificatio
       generateCapturedAnswers = generateCapturedAnswers
     )
 
-  private def generateCapturedAnswers(departureIdentificationTypes: Seq[String],
-                                      refDataIdentificationTypes: Seq[LocationOfGoodsIdentification]
+  private def generateCapturedAnswers(
+    departureIdentificationTypes: Seq[String],
+    refDataIdentificationTypes: Seq[LocationOfGoodsIdentification]
   ): Seq[CapturedAnswer] =
     departureIdentificationTypes.flatMap {
       departureIdentificationType =>
+        val page: BaseIdentificationPage = refDataIdentificationTypes.toList match {
+          case _ :: Nil => InferredIdentificationPage
+          case _        => IdentificationPage
+        }
         refDataIdentificationTypes
           .find(_.code == departureIdentificationType)
-          .map((IdentificationPage, _))
+          .map((page, _))
     }
 
   private def getLocationType(userAnswers: UserAnswers): Option[String] =

--- a/app/utils/transformer/locationOfGoods/LocationTypeTransformer.scala
+++ b/app/utils/transformer/locationOfGoods/LocationTypeTransformer.scala
@@ -17,7 +17,7 @@
 package utils.transformer.locationOfGoods
 
 import models.{LocationType, RichCC015CType, UserAnswers}
-import pages.locationOfGoods.LocationTypePage
+import pages.locationOfGoods.{BaseLocationTypePage, InferredLocationTypePage, LocationTypePage}
 import services.LocationTypeService
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.transformer.PageTransformer
@@ -44,9 +44,13 @@ class LocationTypeTransformer @Inject() (service: LocationTypeService)(implicit
   private def generateCapturedAnswers(departureLocationTypes: Seq[String], refDataLocationTypes: Seq[LocationType]): Seq[CapturedAnswer] =
     departureLocationTypes.flatMap {
       departureLocationType =>
+        val page: BaseLocationTypePage = refDataLocationTypes.toList match {
+          case _ :: Nil => InferredLocationTypePage
+          case _        => LocationTypePage
+        }
         refDataLocationTypes
           .find(_.code == departureLocationType)
-          .map((LocationTypePage, _))
+          .map((page, _))
     }
 
 }

--- a/test/navigator/BorderNavigatorSpec.scala
+++ b/test/navigator/BorderNavigatorSpec.scala
@@ -61,10 +61,10 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
             .nextPage(AddAnotherBorderMeansOfTransportYesNoPage(activeIndex), userAnswers, departureId, mode)
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
         }
-        "to session expired when AddAnotherBorderMeansOfTransportYesNoPage does not exist" in {
+        "to tech difficulties when AddAnotherBorderMeansOfTransportYesNoPage does not exist" in {
           navigator
             .nextPage(AddAnotherBorderMeansOfTransportYesNoPage(activeIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
 
       }
@@ -382,10 +382,10 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
           .nextPage(AddConveyanceReferenceYesNoPage(activeIndex), userAnswers, departureId, NormalMode)
           .mustBe(routes.ConveyanceReferenceNumberController.onPageLoad(departureId, NormalMode, activeIndex))
       }
-      "to session expired when AddConveyanceReferenceYesNoPage does not exist" in {
+      "to tech difficulties when AddConveyanceReferenceYesNoPage does not exist" in {
         navigator
           .nextPage(AddConveyanceReferenceYesNoPage(activeIndex), emptyUserAnswers, departureId, mode)
-          .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+          .mustBe(controllers.routes.ErrorController.technicalDifficulties())
       }
 
       "when selected no on add conveyance number yes no" - {

--- a/test/navigator/BorderNavigatorSpec.scala
+++ b/test/navigator/BorderNavigatorSpec.scala
@@ -531,19 +531,6 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
 
         }
-
-        "to CheckYourAnswers when Yes and there is an answer to border mode of transport in IE15/13" in {
-
-          val userAnswers = emptyUserAnswers
-            .setValue(AddBorderModeOfTransportYesNoPage, true)
-            .copy(departureData =
-              emptyUserAnswers.departureData.copy(Consignment = emptyUserAnswers.departureData.Consignment.copy(modeOfTransportAtTheBorder = Some("test")))
-            )
-          navigator
-            .nextPage(AddBorderModeOfTransportYesNoPage, userAnswers, departureId, mode)
-            .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-
-        }
       }
 
       "must go from AddInlandModeYesNoPage" - {
@@ -581,19 +568,6 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
 
         }
-
-        "to CheckYourAnswers when Yes and there is an answer to inlandMode in IE15/13" in {
-
-          val userAnswers = emptyUserAnswers
-            .setValue(AddInlandModeOfTransportYesNoPage, true)
-            .copy(departureData =
-              emptyUserAnswers.departureData.copy(Consignment = emptyUserAnswers.departureData.Consignment.copy(inlandModeOfTransport = Some("test")))
-            )
-          navigator
-            .nextPage(AddInlandModeOfTransportYesNoPage, userAnswers, departureId, mode)
-            .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-
-        }
       }
 
       "must go from InlandModePage" - {
@@ -622,19 +596,6 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
           val userAnswers = emptyUserAnswers
             .setValue(AddInlandModeOfTransportYesNoPage, true)
             .setValue(InlandModePage, InlandMode("1", "Air"))
-          navigator
-            .nextPage(AddInlandModeOfTransportYesNoPage, userAnswers, departureId, mode)
-            .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
-
-        }
-
-        "to CheckYourAnswers when Yes and there is an answer to inlandMode in IE15/13" in {
-
-          val userAnswers = emptyUserAnswers
-            .setValue(AddInlandModeOfTransportYesNoPage, true)
-            .copy(departureData =
-              emptyUserAnswers.departureData.copy(Consignment = emptyUserAnswers.departureData.Consignment.copy(inlandModeOfTransport = Some("test")))
-            )
           navigator
             .nextPage(AddInlandModeOfTransportYesNoPage, userAnswers, departureId, mode)
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))

--- a/test/navigator/BorderNavigatorSpec.scala
+++ b/test/navigator/BorderNavigatorSpec.scala
@@ -795,8 +795,8 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
             forAll(arbitrary[String](arbitrarySecurityDetailsNonZeroType), nonEmptyString, nonEmptyString) {
               (securityType, borderModeDesc, conveyanceRefNumber) =>
                 val userAnswers = emptyUserAnswers
-                  .setValue(ConveyanceReferenceNumberPage(activeIndex), conveyanceRefNumber)
                   .setValue(BorderModeOfTransportPage, BorderMode("4", borderModeDesc))
+                  .setValue(ConveyanceReferenceNumberPage(activeIndex), conveyanceRefNumber)
                   .copy(departureData =
                     basicIe015.copy(
                       TransitOperation = basicIe015.TransitOperation.copy(security = securityType)
@@ -822,8 +822,8 @@ class BorderNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with Ge
             forAll(arbitrary[String](arbitrarySecurityDetailsNonZeroType), nonEmptyString, nonEmptyString) {
               (securityType, borderModeDesc, conveyanceRefNumber) =>
                 val userAnswers = emptyUserAnswers
-                  .setValue(AddConveyanceReferenceYesNoPage(activeIndex), true)
                   .setValue(BorderModeOfTransportPage, BorderMode("3", borderModeDesc))
+                  .setValue(AddConveyanceReferenceYesNoPage(activeIndex), true)
                   .copy(departureData =
                     basicIe015.copy(
                       TransitOperation = basicIe015.TransitOperation.copy(security = securityType)

--- a/test/navigator/ContainerNavigatorSpec.scala
+++ b/test/navigator/ContainerNavigatorSpec.scala
@@ -128,10 +128,10 @@ class ContainerNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with
           .mustBe(controllers.transport.equipment.routes.AddTransportEquipmentYesNoController.onPageLoad(departureId, CheckMode))
       }
 
-      "to session expired when ContainerIndicatorPage does not exist" in {
+      "to tech difficulties when ContainerIndicatorPage does not exist" in {
         navigator
           .nextPage(ContainerIndicatorPage, emptyUserAnswers, departureId, CheckMode)
-          .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+          .mustBe(controllers.routes.ErrorController.technicalDifficulties())
       }
 
     }

--- a/test/navigator/DepartureTransportMeansNavigatorSpec.scala
+++ b/test/navigator/DepartureTransportMeansNavigatorSpec.scala
@@ -102,10 +102,10 @@ class DepartureTransportMeansNavigatorSpec extends SpecBase with ScalaCheckPrope
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
         }
 
-        "to session expired when AddAnotherTransportMeansPage does not exist" in {
+        "to tech difficulties when AddAnotherTransportMeansPage does not exist" in {
           navigator
             .nextPage(AddAnotherTransportMeansPage(transportIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
       }
 
@@ -206,10 +206,10 @@ class DepartureTransportMeansNavigatorSpec extends SpecBase with ScalaCheckPrope
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
         }
 
-        "to session expired when AddAnotherTransportMeansPage does not exist" in {
+        "to tech difficulties when AddAnotherTransportMeansPage does not exist" in {
           navigator
             .nextPage(AddAnotherTransportMeansPage(transportIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
       }
 

--- a/test/navigator/EquipmentNavigatorSpec.scala
+++ b/test/navigator/EquipmentNavigatorSpec.scala
@@ -68,10 +68,10 @@ class EquipmentNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with
 
         }
 
-        "to session expired when AddContainerIdentificationNumberYesNoPage does not exist" in {
+        "to tech difficulties when AddContainerIdentificationNumberYesNoPage does not exist" in {
           navigator
             .nextPage(AddContainerIdentificationNumberYesNoPage(equipmentIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
       }
 
@@ -300,10 +300,10 @@ class EquipmentNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with
           }
         }
 
-        "to session expired when AddSealYesNoPage does not exist" in {
+        "to tech difficulties when AddSealYesNoPage does not exist" in {
           navigator
             .nextPage(AddSealYesNoPage(equipmentIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
       }
 
@@ -330,10 +330,10 @@ class EquipmentNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with
             .nextPage(AddAnotherSealPage(equipmentIndex, Index(2)), userAnswers, departureId, mode)
             .mustBe(SealIdentificationNumberPage(equipmentIndex, Index(2)).route(userAnswers, departureId, mode).value)
         }
-        "to session expired when AddAnotherSealPage does not exist" in {
+        "to tech difficulties when AddAnotherSealPage does not exist" in {
           navigator
             .nextPage(AddAnotherSealPage(equipmentIndex, itemIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
       }
 
@@ -414,10 +414,10 @@ class EquipmentNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with
 
           }
         }
-        "to session expired when AddAnotherTransportEquipmentPage does not exist" in {
+        "to tech difficulties when AddAnotherTransportEquipmentPage does not exist" in {
           navigator
             .nextPage(AddAnotherTransportEquipmentPage(equipmentIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
       }
 
@@ -653,10 +653,10 @@ class EquipmentNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with
                 .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
           }
         }
-        "to session expired when ApplyAnotherItemPage does not exist" in {
+        "to tech difficulties when ApplyAnotherItemPage does not exist" in {
           navigator
             .nextPage(ApplyAnotherItemPage(equipmentIndex, itemIndex), emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
       }
 

--- a/test/navigator/LoadingNavigatorSpec.scala
+++ b/test/navigator/LoadingNavigatorSpec.scala
@@ -71,10 +71,10 @@ class LoadingNavigatorSpec extends SpecBase with ScalaCheckPropertyChecks with G
       }
 
       "must go from AddExtraInformationYesNoPage" - {
-        "to session expired when AddExtraInformationYesNoPage does not exist" in {
+        "to tech difficulties when AddExtraInformationYesNoPage does not exist" in {
           navigator
             .nextPage(AddExtraInformationYesNoPage, emptyUserAnswers, departureId, mode)
-            .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+            .mustBe(controllers.routes.ErrorController.technicalDifficulties())
         }
 
         "to Country page when answer is Yes" in {

--- a/test/navigator/LocationOfGoodsNavigatorSpec.scala
+++ b/test/navigator/LocationOfGoodsNavigatorSpec.scala
@@ -187,8 +187,9 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         )
         val simplifiedUserAnswers = userAnswers.copy(departureData = departureData)
 
-        val result = navigator.locationOfGoodsNavigation(simplifiedUserAnswers, departureId, mode).get
-        result.mustBe(controllers.locationOfGoods.routes.LocationTypeController.onPageLoad(departureId, mode))
+        navigator
+          .nextPage(MoreInformationPage, simplifiedUserAnswers, departureId, mode)
+          .mustBe(controllers.locationOfGoods.routes.LocationTypeController.onPageLoad(departureId, mode))
       }
 
       "redirect to LocationTypeController when locationOfGoods is None and is simplified" in {
@@ -199,8 +200,9 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         )
         val simplifiedUserAnswers = userAnswers.copy(departureData = departureData)
 
-        val result = navigator.locationOfGoodsNavigation(simplifiedUserAnswers, departureId, mode).get
-        result.mustBe(controllers.locationOfGoods.routes.LocationTypeController.onPageLoad(departureId, mode))
+        navigator
+          .nextPage(MoreInformationPage, simplifiedUserAnswers, departureId, mode)
+          .mustBe(controllers.locationOfGoods.routes.LocationTypeController.onPageLoad(departureId, mode))
       }
 
       "must go from EORI Page to Add Additional Identifier Yes No page" in {

--- a/test/navigator/LocationOfGoodsNavigatorSpec.scala
+++ b/test/navigator/LocationOfGoodsNavigatorSpec.scala
@@ -33,8 +33,6 @@ import pages.loading.CountryPage
 import pages.locationOfGoods._
 import pages.locationOfGoods.contact.{NamePage, PhoneNumberPage}
 import pages.transport.border.BorderModeOfTransportPage
-import pages.transport.equipment.AddTransportEquipmentYesNoPage
-import pages.transport.equipment.index.ContainerIdentificationNumberPage
 import pages.transport.{CheckInformationPage, ContainerIndicatorPage, LimitDatePage}
 import pages.{MoreInformationPage, Page}
 import scalaxb.XMLCalendar
@@ -308,7 +306,6 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
           (answers, placeOfLoading, limitDate) =>
             val updatedAnswers = answers
               .setValue(AddContactYesNoPage, false)
-              .setValue(LimitDatePage, LocalDate.now())
               .copy(departureData =
                 answers.departureData.copy(
                   TransitOperation = answers.departureData.TransitOperation.copy(limitDate = Some(limitDate)),
@@ -325,27 +322,28 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         }
       }
 
-      "must go from Add AddContactYesNo page to ContainerIdentificationNumberPage page when user selects no, Security is NoSecurityDetails, Add contact is false, Container Indicator is true" in {
-        forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03]) {
-          (answers, locationOfGoods, placeOfLoading) =>
+      "must go from Add AddContactYesNo page to CYA page when user selects no, Security is NoSecurityDetails, Add contact is false, Container Indicator is true" in {
+        forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03], arbitrary[XMLGregorianCalendar]) {
+          (answers, locationOfGoods, placeOfLoading, limitDate) =>
             val updatedAnswers = answers
               .setValue(AddContactYesNoPage, false)
-              .setValue(ContainerIndicatorPage, true)
-              .setValue(LimitDatePage, LocalDate.now())
               .copy(departureData =
                 answers.departureData.copy(
-                  TransitOperation = answers.departureData.TransitOperation.copy(security = NoSecurityDetails),
+                  TransitOperation = answers.departureData.TransitOperation.copy(
+                    security = NoSecurityDetails,
+                    limitDate = Some(limitDate)
+                  ),
                   Consignment = answers.departureData.Consignment.copy(
                     LocationOfGoods = Some(locationOfGoods),
                     PlaceOfLoading = Some(placeOfLoading),
-                    containerIndicator = None
+                    containerIndicator = Some(Number1)
                   )
                 )
               )
 
             navigator
               .nextPage(AddContactYesNoPage, updatedAnswers, departureId, NormalMode)
-              .mustBe(controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex))
+              .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
         }
       }
 
@@ -528,32 +526,30 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
             .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
         }
 
-      "must go from Add PhoneNumberPage page to ContainerIdentificationNumberPage page " +
+      "must go from Add PhoneNumberPage page to CYA page " +
         "when user selects No and POL & limit date exists and Container Indicator exists" +
         "and security is '0'" +
         "and active border means is present" +
         "and container indicator is '1'" in {
-          forAll(arbitrary[UserAnswers], arbitrary[PlaceOfLoadingType03]) {
-            (answers, placeOfLoading) =>
+          forAll(arbitrary[UserAnswers], arbitrary[PlaceOfLoadingType03], arbitrary[XMLGregorianCalendar]) {
+            (answers, placeOfLoading, limitDate) =>
               val updatedAnswers = answers
                 .setValue(AddContactYesNoPage, false)
-                .setValue(ContainerIndicatorPage, true)
-                .setValue(LimitDatePage, LocalDate.now())
                 .copy(departureData =
                   answers.departureData.copy(
                     TransitOperation = answers.departureData.TransitOperation.copy(
                       security = NoSecurityDetails,
-                      limitDate = Some(XMLCalendar("2020-01-01T09:30:00"))
+                      limitDate = Some(limitDate)
                     ),
                     Consignment = answers.departureData.Consignment.copy(
-                      containerIndicator = None,
+                      containerIndicator = Some(Number1),
                       PlaceOfLoading = Some(placeOfLoading)
                     )
                   )
                 )
               navigator
                 .nextPage(PhoneNumberPage, updatedAnswers, departureId, NormalMode)
-                .mustBe(ContainerIdentificationNumberPage(equipmentIndex).route(answers, departureId, mode).value)
+                .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
           }
         }
       "must go from Add PhoneNumberPage page to AddTransportEquipmentYesNoPage " +
@@ -563,27 +559,25 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         "and active border means is present" +
         "and container indicator is '0'" in {
 
-          forAll(arbitrary[UserAnswers], arbitrary[PlaceOfLoadingType03]) {
-            (answers, placeOfLoading) =>
+          forAll(arbitrary[UserAnswers], arbitrary[PlaceOfLoadingType03], arbitrary[XMLGregorianCalendar]) {
+            (answers, placeOfLoading, limitDate) =>
               val updatedAnswers = answers
                 .setValue(AddContactYesNoPage, false)
-                .setValue(ContainerIndicatorPage, false)
-                .setValue(LimitDatePage, LocalDate.now())
                 .copy(departureData =
                   answers.departureData.copy(
                     TransitOperation = answers.departureData.TransitOperation.copy(
                       security = NoSecurityDetails,
-                      limitDate = Some(XMLCalendar("2020-01-01T09:30:00"))
+                      limitDate = Some(limitDate)
                     ),
                     Consignment = answers.departureData.Consignment.copy(
-                      containerIndicator = None,
+                      containerIndicator = Some(Number0),
                       PlaceOfLoading = Some(placeOfLoading)
                     )
                   )
                 )
               navigator
                 .nextPage(PhoneNumberPage, updatedAnswers, departureId, NormalMode)
-                .mustBe(AddTransportEquipmentYesNoPage.route(answers, departureId, mode).value)
+                .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
           }
         }
 
@@ -592,17 +586,18 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         "consignment contains LocationOfGoods, " +
         "Security is NoSecurityDetails, " +
         "Container Indicator is true" in {
-          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03]) {
-            (answers, locationOfGoods, placeOfLoading) =>
+          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03], arbitrary[XMLGregorianCalendar]) {
+            (answers, locationOfGoods, placeOfLoading, limitDate) =>
               val updatedAnswers = answers
-                .setValue(ContainerIndicatorPage, true)
-                .setValue(LimitDatePage, LocalDate.now())
                 .copy(departureData =
                   answers.departureData.copy(
-                    TransitOperation = answers.departureData.TransitOperation.copy(security = NoSecurityDetails),
+                    TransitOperation = answers.departureData.TransitOperation.copy(
+                      security = NoSecurityDetails,
+                      limitDate = Some(limitDate)
+                    ),
                     Consignment = answers.departureData.Consignment.copy(
                       LocationOfGoods = Some(locationOfGoods),
-                      containerIndicator = None,
+                      containerIndicator = Some(Number1),
                       PlaceOfLoading = Some(placeOfLoading)
                     )
                   )
@@ -610,7 +605,7 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
 
               navigator
                 .nextPage(MoreInformationPage, updatedAnswers, departureId, NormalMode)
-                .mustBe(controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex))
+                .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
           }
         }
 
@@ -672,16 +667,16 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         "Place of loading is present AND container indicator is NOT captured in IE170 AND " +
         "is C521 AND limit date exists AND container indicator is present (in 13/15) AND security is 0 AND Mode of transport is 5" in {
 
-          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03]) {
-            (answers, locationOfGoods, placeOfLoading) =>
+          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03], arbitrary[XMLGregorianCalendar]) {
+            (answers, locationOfGoods, placeOfLoading, limitDate) =>
               val updatedAnswers = answers
-                .setValue(ContainerIndicatorPage, None)
-                .setValue(BorderModeOfTransportPage, BorderMode(Mail, "description"))
-                .setValue(LimitDatePage, LocalDate.now())
                 .copy(departureData =
                   answers.departureData.copy(
                     Authorisation = Seq(AuthorisationType03("1", ACR, "")),
-                    TransitOperation = answers.departureData.TransitOperation.copy(security = NoSecurityDetails),
+                    TransitOperation = answers.departureData.TransitOperation.copy(
+                      security = NoSecurityDetails,
+                      limitDate = Some(limitDate)
+                    ),
                     Consignment = answers.departureData.Consignment.copy(
                       LocationOfGoods = Some(locationOfGoods),
                       PlaceOfLoading = Some(placeOfLoading),
@@ -700,15 +695,17 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         "Place of loading is present AND container indicator is NOT captured in IE170 AND " +
         "is C521 AND container indicator is present (in 13/15) AND security is 0 AND Mode of transport is 4" in {
 
-          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03]) {
-            (answers, locationOfGoods, placeOfLoading) =>
+          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03], arbitrary[XMLGregorianCalendar]) {
+            (answers, locationOfGoods, placeOfLoading, limitDate) =>
               val updatedAnswers = answers
                 .setValue(ContainerIndicatorPage, None)
-                .setValue(BorderModeOfTransportPage, BorderMode(Air, "description"))
                 .copy(departureData =
                   answers.departureData.copy(
                     Authorisation = Seq(AuthorisationType03("1", ACR, "")),
-                    TransitOperation = answers.departureData.TransitOperation.copy(security = NoSecurityDetails),
+                    TransitOperation = answers.departureData.TransitOperation.copy(
+                      security = NoSecurityDetails,
+                      limitDate = Some(limitDate)
+                    ),
                     Consignment = answers.departureData.Consignment.copy(
                       LocationOfGoods = Some(locationOfGoods),
                       PlaceOfLoading = Some(placeOfLoading),
@@ -716,7 +713,6 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
                     )
                   )
                 )
-                .setValue(LimitDatePage, LocalDate.now())
 
               navigator
                 .nextPage(CustomsOfficeIdentifierPage, updatedAnswers, departureId, NormalMode)
@@ -882,25 +878,26 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         "consignment contains LocationOfGoods, " +
         "Security is NoSecurityDetails, " +
         "Container Indicator is true" in {
-          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03]) {
-            (answers, locationOfGoods, placeOfLoading) =>
+          forAll(arbitrary[UserAnswers], arbitrary[LocationOfGoodsType05], arbitrary[PlaceOfLoadingType03], arbitrary[XMLGregorianCalendar]) {
+            (answers, locationOfGoods, placeOfLoading, limitDate) =>
               val updatedAnswers = answers
-                .setValue(ContainerIndicatorPage, true)
                 .copy(departureData =
                   answers.departureData.copy(
-                    TransitOperation = answers.departureData.TransitOperation.copy(security = NoSecurityDetails),
+                    TransitOperation = answers.departureData.TransitOperation.copy(
+                      security = NoSecurityDetails,
+                      limitDate = Some(limitDate)
+                    ),
                     Consignment = answers.departureData.Consignment.copy(
                       LocationOfGoods = Some(locationOfGoods),
-                      containerIndicator = None,
+                      containerIndicator = Some(Number1),
                       PlaceOfLoading = Some(placeOfLoading)
                     )
                   )
                 )
-                .setValue(LimitDatePage, LocalDate.now())
 
               navigator
                 .nextPage(CustomsOfficeIdentifierPage, updatedAnswers, departureId, NormalMode)
-                .mustBe(controllers.transport.equipment.index.routes.ContainerIdentificationNumberController.onPageLoad(departureId, mode, equipmentIndex))
+                .mustBe(controllers.routes.CheckYourAnswersController.onPageLoad(departureId))
           }
         }
 

--- a/test/navigator/LocationOfGoodsNavigatorSpec.scala
+++ b/test/navigator/LocationOfGoodsNavigatorSpec.scala
@@ -236,10 +236,10 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         }
       }
 
-      "must go from AddIdentifierYesNoPage to session expired when AddIdentifierYesNoPage does not exist" in {
+      "must go from AddIdentifierYesNoPage to tech difficulties when AddIdentifierYesNoPage does not exist" in {
         navigator
           .nextPage(AddIdentifierYesNoPage, emptyUserAnswers, departureId, mode)
-          .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+          .mustBe(controllers.routes.ErrorController.technicalDifficulties())
       }
 
       "must go from Add AdditionalIdentifierYesNo page to AddContactYesNo page when user selects No" in {
@@ -284,10 +284,10 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         }
       }
 
-      "must go from AddContactYesNoPage to session expired when AddContactYesNoPage does not exist" in {
+      "must go from AddContactYesNoPage to tech difficulties when AddContactYesNoPage does not exist" in {
         navigator
           .nextPage(AddContactYesNoPage, emptyUserAnswers, departureId, mode)
-          .mustBe(controllers.routes.SessionExpiredController.onPageLoad())
+          .mustBe(controllers.routes.ErrorController.technicalDifficulties())
       }
 
       "must go from Add AddContactYesNo page to AddUnLocode page when user selects No and POL does not exist" in {

--- a/test/navigator/LocationOfGoodsNavigatorSpec.scala
+++ b/test/navigator/LocationOfGoodsNavigatorSpec.scala
@@ -483,10 +483,11 @@ class LocationOfGoodsNavigatorSpec extends SpecBase with ScalaCheckPropertyCheck
         val userAnswers = emptyUserAnswers.setValue(CountryPage, arbitraryCountry.arbitrary.sample.value)
         val userAnswersUpdated = userAnswers
           .copy(
-            departureData = userAnswers.departureData.copy(Consignment = userAnswers.departureData.Consignment.copy(containerIndicator = None))
+            departureData = userAnswers.departureData.copy(
+              Consignment = userAnswers.departureData.Consignment.copy(containerIndicator = Some(Number1))
+            )
           )
           .setValue(LimitDatePage, LocalDate.now())
-          .setValue(ContainerIndicatorPage, true)
 
         navigator
           .nextPage(LimitDatePage, userAnswersUpdated, departureId, mode)

--- a/test/pages/transport/border/BorderModeOfTransportPageSpec.scala
+++ b/test/pages/transport/border/BorderModeOfTransportPageSpec.scala
@@ -45,6 +45,7 @@ class BorderModeOfTransportPageSpec extends PageBehaviours {
 
           val result = userAnswers.setValue(BorderModeOfTransportPage, borderMode)
 
+          result.get(AddBorderModeOfTransportYesNoPage).value mustBe true
           result.get(AddBorderMeansOfTransportYesNoPage) mustNot be(defined)
           result.get(NationalityPage(Index(0))) mustNot be(defined)
           result.get(IdentificationNumberPage(Index(0))) mustNot be(defined)

--- a/test/pages/transport/border/BorderModeOfTransportPageSpec.scala
+++ b/test/pages/transport/border/BorderModeOfTransportPageSpec.scala
@@ -16,12 +16,11 @@
 
 package pages.transport.border
 
-import models.Index
-import models.reference.Nationality
 import models.reference.TransportMode.BorderMode
 import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
-import pages.transport.border.active.{IdentificationNumberPage, NationalityPage}
+import pages.sections.transport.border.BorderActiveListSection
+import play.api.libs.json.{JsArray, Json}
 
 class BorderModeOfTransportPageSpec extends PageBehaviours {
 
@@ -40,19 +39,14 @@ class BorderModeOfTransportPageSpec extends PageBehaviours {
         borderMode =>
           val userAnswers = emptyUserAnswers
             .setValue(AddBorderMeansOfTransportYesNoPage, true)
-            .setValue(NationalityPage(Index(0)), Nationality("GB", "United Kingdom"))
-            .setValue(IdentificationNumberPage(Index(0)), "12345")
+            .setValue(BorderActiveListSection, JsArray(Seq(Json.obj("foo" -> "bar"))))
 
           val result = userAnswers.setValue(BorderModeOfTransportPage, borderMode)
 
           result.get(AddBorderModeOfTransportYesNoPage).value mustBe true
           result.get(AddBorderMeansOfTransportYesNoPage) mustNot be(defined)
-          result.get(NationalityPage(Index(0))) mustNot be(defined)
-          result.get(IdentificationNumberPage(Index(0))) mustNot be(defined)
-
+          result.get(BorderActiveListSection) mustNot be(defined)
       }
-
     }
   }
-
 }

--- a/test/utils/transformer/locationOfGoods/AddIdentifierYesNoTransformerTest.scala
+++ b/test/utils/transformer/locationOfGoods/AddIdentifierYesNoTransformerTest.scala
@@ -22,37 +22,69 @@ import generators.Generators
 import models.LocationOfGoodsIdentification
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import pages.locationOfGoods.{AddIdentifierYesNoPage, IdentificationPage}
+import pages.locationOfGoods.{AddIdentifierYesNoPage, IdentificationPage, InferredIdentificationPage}
 
 class AddIdentifierYesNoTransformerTest extends SpecBase with Generators {
   val transformer = new AddIdentifierYesNoTransformer()
 
   "AddIdentifierYesNoTransformer" - {
-    "must return AddIdentifierYesNoPage Yes (true) when there is additionalIdentifier and identification is X or Y" in {
-      forAll(arbitrary[LocationOfGoodsType05], nonEmptyString, Gen.oneOf("X", "Y")) {
-        (locationOfGoods, additionalIdentifier, identification) =>
-          val userAnswers = setLocationOfGoodsOnUserAnswersLens
-            .set(
-              Some(locationOfGoods.copy(additionalIdentifier = Some(additionalIdentifier)))
-            )(emptyUserAnswers)
-            .setValue(IdentificationPage, LocationOfGoodsIdentification(identification, "description"))
+    "must return AddIdentifierYesNoPage Yes (true) when there is additionalIdentifier" - {
+      "and identification is X or Y" in {
+        forAll(arbitrary[LocationOfGoodsType05], nonEmptyString, Gen.oneOf("X", "Y")) {
+          (locationOfGoods, additionalIdentifier, identification) =>
+            val userAnswers = setLocationOfGoodsOnUserAnswersLens
+              .set(
+                Some(locationOfGoods.copy(additionalIdentifier = Some(additionalIdentifier)))
+              )(emptyUserAnswers)
+              .setValue(IdentificationPage, LocationOfGoodsIdentification(identification, "description"))
 
-          val result = transformer.transform.apply(userAnswers).futureValue
-          result.get(AddIdentifierYesNoPage).get mustBe true
+            val result = transformer.transform.apply(userAnswers).futureValue
+            result.get(AddIdentifierYesNoPage).get mustBe true
+        }
+      }
+
+      "and inferred identification is X or Y" in {
+        forAll(arbitrary[LocationOfGoodsType05], nonEmptyString, Gen.oneOf("X", "Y")) {
+          (locationOfGoods, additionalIdentifier, identification) =>
+            val userAnswers = setLocationOfGoodsOnUserAnswersLens
+              .set(
+                Some(locationOfGoods.copy(additionalIdentifier = Some(additionalIdentifier)))
+              )(emptyUserAnswers)
+              .setValue(InferredIdentificationPage, LocationOfGoodsIdentification(identification, "description"))
+
+            val result = transformer.transform.apply(userAnswers).futureValue
+            result.get(AddIdentifierYesNoPage).get mustBe true
+        }
       }
     }
 
-    "must return AddIdentifierYesNoPage No (false) when there is no additionalIdentifier and identification is X or Y" in {
-      forAll(arbitrary[LocationOfGoodsType05], Gen.oneOf("X", "Y")) {
-        (locationOfGoods, identification) =>
-          val userAnswers = setLocationOfGoodsOnUserAnswersLens
-            .set(
-              Some(locationOfGoods.copy(additionalIdentifier = None))
-            )(emptyUserAnswers)
-            .setValue(IdentificationPage, LocationOfGoodsIdentification(identification, "description"))
+    "must return AddIdentifierYesNoPage No (false) when there is no additionalIdentifier" - {
+      "and identification is X or Y" in {
+        forAll(arbitrary[LocationOfGoodsType05], Gen.oneOf("X", "Y")) {
+          (locationOfGoods, identification) =>
+            val userAnswers = setLocationOfGoodsOnUserAnswersLens
+              .set(
+                Some(locationOfGoods.copy(additionalIdentifier = None))
+              )(emptyUserAnswers)
+              .setValue(IdentificationPage, LocationOfGoodsIdentification(identification, "description"))
 
-          val result = transformer.transform.apply(userAnswers).futureValue
-          result.get(AddIdentifierYesNoPage).get mustBe false
+            val result = transformer.transform.apply(userAnswers).futureValue
+            result.get(AddIdentifierYesNoPage).get mustBe false
+        }
+      }
+
+      "and inferred identification is X or Y" in {
+        forAll(arbitrary[LocationOfGoodsType05], Gen.oneOf("X", "Y")) {
+          (locationOfGoods, identification) =>
+            val userAnswers = setLocationOfGoodsOnUserAnswersLens
+              .set(
+                Some(locationOfGoods.copy(additionalIdentifier = None))
+              )(emptyUserAnswers)
+              .setValue(InferredIdentificationPage, LocationOfGoodsIdentification(identification, "description"))
+
+            val result = transformer.transform.apply(userAnswers).futureValue
+            result.get(AddIdentifierYesNoPage).get mustBe false
+        }
       }
     }
 

--- a/test/viewModels/transport/border/active/AddAnotherBorderTransportViewModelSpec.scala
+++ b/test/viewModels/transport/border/active/AddAnotherBorderTransportViewModelSpec.scala
@@ -223,15 +223,15 @@ class AddAnotherBorderTransportViewModelSpec extends SpecBase with Generators wi
                     CustomsOfficeOfTransitDeclared = Nil
                   )
                 )
+                .setValue(BorderModeOfTransportPage, BorderMode(Air, "test"))
                 .setValue(IdentificationPage(Index(0)), identification)
                 .setValue(IdentificationNumberPage(Index(0)), identificationNumber)
-                .setValue(BorderModeOfTransportPage, BorderMode(Air, "test"))
 
               val result = new AddAnotherBorderTransportViewModelProvider().apply(userAnswers, departureId, NormalMode)
 
               result.listItems mustBe Seq(
                 ListItem(
-                  name = s"${identification.asString}",
+                  name = s"${identification.asString} - $identificationNumber",
                   changeUrl = controllers.transport.border.active.routes.IdentificationController.onPageLoad(departureId, NormalMode, Index(0)).url,
                   removeUrl = None
                 )


### PR DESCRIPTION
- Fixing navigation bugs, ensuring that IE013/IE015 values are being evaluated during the NormalMode (linear) journey where necessary
- Setting the border mode sets add border mode yes/no to true
- Changing the border mode cleans up all active border transport means
- Setting inferred values where necessary in the transformers (specifically location of goods location type and qualifier of identification)
- Extracting common navigation code into trait
- Ensuring we are not redirecting to session expired when our navigation logic falls over. Taking them to technical difficulties instead.