### PR TITLE
feat(CTCP-5213): remove autocomplete since this is rep phone and not self

### DIFF
--- a/app/views/representative/RepresentativePhoneNumberView.scala.html
+++ b/app/views/representative/RepresentativePhoneNumberView.scala.html
@@ -45,7 +45,6 @@
             ),
             hint = Some(messages("representative.representativeTelephoneNumber.hint")),
             inputType = "tel",
-            autocomplete = Some("tel"),
             inputClass = InputSize.Width20
         )
 

--- a/test/views/behaviours/TelephoneNumberViewBehaviours.scala
+++ b/test/views/behaviours/TelephoneNumberViewBehaviours.scala
@@ -32,7 +32,6 @@ trait TelephoneNumberViewBehaviours extends InputTextViewBehaviours[String] {
       "must contain a telephone number input field" in {
         val input = getElementByTag(doc, "input")
         input.attr("type") mustBe "tel"
-        input.attr("autocomplete") mustBe "tel"
       }
     }
   }


### PR DESCRIPTION
Email from Daniel Elder - daniel.elder@digital.hmrc.gov.uk - Senior Accessibility Specialist - On DAC Issue CTCP 5213.

Hi

Ok, good and bad news.

I've checked the journey and the name now correctly contains autocomplete=name. 

But noticed that the contact person's telephone number contains the autocomplete=tel attribute, which is incorrect as it is not the person's telephone who is completing the form.

Journey 1

8. Who is the contact for the location of goods? - Correct, does not have autocomplete
9. What is Pip Contactova's phone number? - Incorrect, contains autocomplete=tel

32 What is your name - Correct, contains autocomplete=name
33 What is your phone number? Correct, contains autocomplete=tel


The file that needs the autocomplete removed is:

https://github.com/hmrc/ctc-presentation-notification-frontend/blob/main/app/views/locationOfGoods/contact/PhoneNumberView.scala.html

Apologies for the oversight.

Dan.